### PR TITLE
ed25519: support scenrios where msg is empty

### DIFF
--- a/cryptokit/Sources/CryptoKitSrc/ed25519.swift
+++ b/cryptokit/Sources/CryptoKitSrc/ed25519.swift
@@ -75,9 +75,7 @@ public func signEd25519(
     messageLength: Int,
     sigBuffer: UnsafeMutablePointer<UInt8>?
 ) -> Int {
-    guard let messagePointer = messagePointer,
-        let sigBuffer = sigBuffer
-    else {
+    guard let sigBuffer = sigBuffer else {
         return -1  // Invalid inputs
     }
 
@@ -93,7 +91,12 @@ public func signEd25519(
     }
 
     // Convert the message to Data
-    let messageData = Data(bytes: messagePointer, count: messageLength)
+    let messageData: Data
+    if let messagePointer = messagePointer, messageLength > 0 {
+        messageData = Data(bytes: messagePointer, count: messageLength)
+    } else {
+        messageData = Data()  // Empty message
+    }
 
     // Sign the message
     let signature: Data
@@ -121,10 +124,8 @@ public func verifyEd25519(
     messageLength: Int,
     sigPointer: UnsafePointer<UInt8>?
 ) -> Int {
-    guard let messagePointer = messagePointer,
-        let sigPointer = sigPointer
-    else {
-        return -1  // Error: invalid inputs
+    guard let sigPointer = sigPointer else {
+        return -1  // Invalid inputs
     }
 
     // Convert the raw public key back to a Data object
@@ -136,7 +137,12 @@ public func verifyEd25519(
     }
 
     // Convert the message and signature to Data
-    let rawMessage = Data(bytes: messagePointer, count: messageLength)
+    let rawMessage: Data
+    if let messagePointer = messagePointer, messageLength > 0 {
+        rawMessage = Data(bytes: messagePointer, count: messageLength)
+    } else {
+        rawMessage = Data()  // Empty message
+    }
     let signatureData = Data(bytes: sigPointer, count: signatureSizeEd25519)
 
     // Verify the signature

--- a/xcrypto/ed25519_test.go
+++ b/xcrypto/ed25519_test.go
@@ -45,6 +45,14 @@ func TestEd25519SignVerify(t *testing.T) {
 	if xcrypto.VerifyEd25519(public, wrongMessage, sig) == nil {
 		t.Errorf("signature of different message accepted")
 	}
+	message = []byte("")
+	sig, err = xcrypto.SignEd25519(private, message)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if xcrypto.VerifyEd25519(public, message, sig) != nil {
+		t.Errorf("valid signature rejected")
+	}
 }
 
 func TestEd25519Malleability(t *testing.T) {


### PR DESCRIPTION
the standard library allows an empty msg to be passed to signEd25519