### PR TITLE
rsa/ecdsa: only defer key when no error generating

### DIFF
--- a/xcrypto/ecdsa.go
+++ b/xcrypto/ecdsa.go
@@ -93,10 +93,10 @@ func GenerateKeyECDSA(curve string) (x, y, d BigInt, err error) {
 
 	keySizeInBits := curveToKeySizeInBits(curve)
 	privKeyDER, privKeyRef, err := createSecKeyRandom(C.kSecAttrKeyTypeECSECPrimeRandom, keySizeInBits)
-	defer C.CFRelease(C.CFTypeRef(privKeyRef))
 	if err != nil {
 		return nil, nil, nil, err
 	}
+	defer C.CFRelease(C.CFTypeRef(privKeyRef))
 	return decodeFromUncompressedAnsiX963Key(privKeyDER, keySize)
 }
 

--- a/xcrypto/evp.go
+++ b/xcrypto/evp.go
@@ -36,7 +36,7 @@ var (
 		crypto.SHA256: C.kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA256,
 		crypto.SHA384: C.kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA384,
 		crypto.SHA512: C.kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA512,
-		0:             C.kSecKeyAlgorithmRSASignatureRaw,
+		0:             C.kSecKeyAlgorithmRSASignatureDigestPKCS1v15Raw,
 	}
 	rsaPSSAlgorithms = map[crypto.Hash]C.CFStringRef{
 		crypto.SHA1:   C.kSecKeyAlgorithmRSASignatureDigestPSSSHA1,

--- a/xcrypto/rsa.go
+++ b/xcrypto/rsa.go
@@ -18,10 +18,10 @@ import (
 // asn1Data is encoded as PKCS#1 ASN1 DER.
 func GenerateKeyRSA(bits int) (asn1Data []byte, err error) {
 	privKeyDER, privKeyRef, err := createSecKeyRandom(C.kSecAttrKeyTypeRSA, bits)
-	defer C.CFRelease(C.CFTypeRef(privKeyRef))
 	if err != nil {
 		return nil, err
 	}
+	C.CFRelease(C.CFTypeRef(privKeyRef))
 	return privKeyDER, nil
 }
 


### PR DESCRIPTION
This was causing test failures

Also fixes the PKCSv15 algorithm when no hash is specified