### PR TITLE
rsa: add logic to ensure that key is same length as signature

### DIFF
--- a/xcrypto/rsa.go
+++ b/xcrypto/rsa.go
@@ -9,6 +9,7 @@ package xcrypto
 import "C"
 import (
 	"crypto"
+	"errors"
 	"hash"
 	"runtime"
 	"strconv"
@@ -123,6 +124,15 @@ func SignRSAPKCS1v15(priv *PrivateKeyRSA, h crypto.Hash, hashed []byte) ([]byte,
 }
 
 func VerifyRSAPKCS1v15(pub *PublicKeyRSA, h crypto.Hash, hashed, sig []byte) error {
+	if pub.withKey(func(key C.SecKeyRef) C.int {
+		size := C.SecKeyGetBlockSize(key)
+		if len(sig) < int(size) {
+			return 0
+		}
+		return 1
+	}) == 0 {
+		return errors.New("crypto/rsa: verification error")
+	}
 	return evpVerify(pub.withKey, algorithmTypePKCS1v15Sig, h, hashed, sig)
 }
 

--- a/xcrypto/rsa_test.go
+++ b/xcrypto/rsa_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto"
 	"crypto/rsa"
 	"encoding/asn1"
+	"encoding/hex"
 	"math/big"
 	"strconv"
 	"testing"
@@ -195,6 +196,58 @@ func TestRSASignVerifyRSAPSS(t *testing.T) {
 		if (err == nil) != test.good {
 			t.Errorf("#%d: bad result, wanted: %t, got: %s", i, test.good, err)
 		}
+	}
+}
+
+type PublicKey struct {
+	N *big.Int
+	E int
+}
+
+func bigFromHex(hex string) *big.Int {
+	n, ok := new(big.Int).SetString(hex, 16)
+	if !ok {
+		panic("bad hex: " + hex)
+	}
+	return n
+}
+
+func fromHex(hexStr string) []byte {
+	s, err := hex.DecodeString(hexStr)
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+
+func TestBoringVerify(t *testing.T) {
+	encodedKey, err := asn1.Marshal(pkcs1PublicKey{
+		Modulus:  bigFromHex("c4fdf7b40a5477f206e6ee278eaef888ca73bf9128a9eef9f2f1ddb8b7b71a4c07cfa241f028a04edb405e4d916c61d6beabc333813dc7b484d2b3c52ee233c6a79b1eea4e9cc51596ba9cd5ac5aeb9df62d86ea051055b79d03f8a4fa9f38386f5bd17529138f3325d46801514ea9047977e0829ed728e68636802796801be1"),
+		Exponent: 65537,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pub, err := xcrypto.NewPublicKeyRSA(encodedKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hash := fromHex("019c5571724fb5d0e47a4260c940e9803ba05a44")
+	paddedHash := fromHex("3021300906052b0e03021a05000414019c5571724fb5d0e47a4260c940e9803ba05a44")
+
+	// signature is one byte shorter than key.N.
+	sig := fromHex("5edfbeb6a73e7225ad3cc52724e2872e04260d7daf0d693c170d8c4b243b8767bc7785763533febc62ec2600c30603c433c095453ede59ff2fcabeb84ce32e0ed9d5cf15ffcbc816202b64370d4d77c1e9077d74e94a16fb4fa2e5bec23a56d7a73cf275f91691ae1801a976fcde09e981a2f6327ac27ea1fecf3185df0d56")
+
+	err = xcrypto.VerifyRSAPKCS1v15(pub, 0, paddedHash, sig)
+	if err == nil {
+		t.Errorf("raw: expected verification error")
+	}
+
+	err = xcrypto.VerifyRSAPKCS1v15(pub, crypto.SHA1, hash, sig)
+	if err == nil {
+		t.Errorf("sha1: expected verification error")
 	}
 }
 


### PR DESCRIPTION
This logic is already in the openssl repo https://github.com/golang-fips/openssl/blob/v2/rsa.go#L286-L294

