### PR TITLE
add cgo build constraint

### DIFF
--- a/internal/cryptokit/cryptokit.go
+++ b/internal/cryptokit/cryptokit.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//go:build darwin
+//go:build darwin && cgo
 
 package cryptokit
 

--- a/internal/cryptokit/ed25519.go
+++ b/internal/cryptokit/ed25519.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//go:build darwin
+//go:build darwin && cgo
 
 package cryptokit
 

--- a/internal/cryptokit/gcm.go
+++ b/internal/cryptokit/gcm.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//go:build darwin
+//go:build darwin && cgo
 
 package cryptokit
 

--- a/internal/cryptokit/hkdf.go
+++ b/internal/cryptokit/hkdf.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//go:build darwin
+//go:build darwin && cgo
 
 package cryptokit
 

--- a/xcrypto/aes.go
+++ b/xcrypto/aes.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//go:build darwin
+//go:build darwin && cgo
 
 package xcrypto
 

--- a/xcrypto/cipher.go
+++ b/xcrypto/cipher.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//go:build darwin
+//go:build darwin && cgo
 
 package xcrypto
 

--- a/xcrypto/des.go
+++ b/xcrypto/des.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//go:build darwin
+//go:build darwin && cgo
 
 package xcrypto
 

--- a/xcrypto/ec.go
+++ b/xcrypto/ec.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//go:build darwin
+//go:build darwin && cgo
 
 package xcrypto
 

--- a/xcrypto/ecdh.go
+++ b/xcrypto/ecdh.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//go:build darwin
+//go:build darwin && cgo
 
 package xcrypto
 

--- a/xcrypto/ecdsa.go
+++ b/xcrypto/ecdsa.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//go:build darwin
+//go:build darwin && cgo
 
 package xcrypto
 

--- a/xcrypto/ed25519.go
+++ b/xcrypto/ed25519.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//go:build darwin
+//go:build darwin && cgo
 
 package xcrypto
 

--- a/xcrypto/evp.go
+++ b/xcrypto/evp.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//go:build darwin
+//go:build darwin && cgo
 
 package xcrypto
 

--- a/xcrypto/hash.go
+++ b/xcrypto/hash.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//go:build darwin
+//go:build darwin && cgo
 
 package xcrypto
 

--- a/xcrypto/hkdf.go
+++ b/xcrypto/hkdf.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//go:build darwin
+//go:build darwin && cgo
 
 package xcrypto
 

--- a/xcrypto/hmac.go
+++ b/xcrypto/hmac.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//go:build darwin
+//go:build darwin && cgo
 
 package xcrypto
 

--- a/xcrypto/pbkdf2.go
+++ b/xcrypto/pbkdf2.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//go:build darwin
+//go:build darwin && cgo
 
 package xcrypto
 

--- a/xcrypto/rand.go
+++ b/xcrypto/rand.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//go:build darwin
+//go:build darwin && cgo
 
 package xcrypto
 

--- a/xcrypto/rc4.go
+++ b/xcrypto/rc4.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//go:build darwin
+//go:build darwin && cgo
 
 package xcrypto
 

--- a/xcrypto/rsa.go
+++ b/xcrypto/rsa.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//go:build darwin
+//go:build darwin && cgo
 
 package xcrypto
 

--- a/xcrypto/xcrypto.go
+++ b/xcrypto/xcrypto.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//go:build darwin
+//go:build darwin && cgo
 
 package xcrypto
 


### PR DESCRIPTION
fixes:

```
 imports github.com/microsoft/go-crypto-darwin/internal/cryptokit: build constraints exclude all Go files in /Users/runner/work/1/s/go/src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokitgo tool dist: FAILED: /Users/runner/work/1/s/go/pkg/tool/darwin_amd64/go_bootstrap install -pgo=off cmd/asm cmd/cgo cmd/compile cmd/link cmd/preprofile: exit status 1
```