### PR TITLE
Import Security and CoreFoundation frameworks

### DIFF
--- a/internal/cryptokit/cryptokit.go
+++ b/internal/cryptokit/cryptokit.go
@@ -6,7 +6,7 @@
 package cryptokit
 
 // #cgo CFLAGS: -Wno-deprecated-declarations
-// #cgo LDFLAGS: -L /Library/Developer/CommandLineTools/usr/lib/swift/macosx ${SRCDIR}/CryptoKit.o
+// #cgo LDFLAGS: -framework Security -framework CoreFoundation -L /Library/Developer/CommandLineTools/usr/lib/swift/macosx ${SRCDIR}/CryptoKit.o
 import "C"
 import "unsafe"
 

--- a/xcrypto/xcrypto.go
+++ b/xcrypto/xcrypto.go
@@ -6,6 +6,7 @@
 package xcrypto
 
 // #cgo CFLAGS: -Wno-deprecated-declarations
+// #cgo LDFLAGS: -framework Security -framework CoreFoundation
 import "C"
 import "unsafe"
 


### PR DESCRIPTION
Importing the `Security` and `CoreFoundation` frameworks are really necessary are necessary for the Go internal linker. If they are not imported, the internal linker complains with this this error: `internal linking requested but external linking required: some packages could not be built to support internal linking ([github.com/microsoft/go-crypto-darwin/xcrypto])`.

The root cause is that the cgo compiler fails with the following error:

```sh
# github.com/microsoft/go-crypto-darwin/xcrypto
Undefined symbols for architecture arm64:
  "_CFDataCreate", referenced from:
      __cgo_56535a2b67fa_Cfunc_CFDataCreate in _x007.o
  "_CFDataGetBytePtr", referenced from:
      __cgo_56535a2b67fa_Cfunc_CFDataGetBytePtr in _x007.o
...
```

This PR still doesn't fix internal linking, but it is a step in the right direction.

For https://github.com/microsoft/go-crypto-darwin/issues/33.