### PR TITLE
Declare kSec keys instead of importing them from C

### DIFF
--- a/xcrypto/ecdh.go
+++ b/xcrypto/ecdh.go
@@ -39,7 +39,7 @@ func NewPublicKeyECDH(curve string, bytes []byte) (*PublicKeyECDH, error) {
 	if len(bytes) < 1 {
 		return nil, errors.New("NewPublicKeyECDH: missing key")
 	}
-	pubKeyRef, err := createSecKeyWithData(bytes, C.kSecAttrKeyTypeECSECPrimeRandom, C.kSecAttrKeyClassPublic)
+	pubKeyRef, err := createSecKeyWithData(bytes, kSecAttrKeyTypeECSECPrimeRandom, kSecAttrKeyClassPublic)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +53,7 @@ func (k *PublicKeyECDH) Bytes() []byte { return k.bytes }
 // bytes expects the public key to be in uncompressed ANSI X9.63 format
 func NewPrivateKeyECDH(curve string, pub, priv []byte) (*PrivateKeyECDH, error) {
 	key := append(slices.Clone(pub), priv...)
-	privKeyRef, err := createSecKeyWithData(key, C.kSecAttrKeyTypeECSECPrimeRandom, C.kSecAttrKeyClassPrivate)
+	privKeyRef, err := createSecKeyWithData(key, kSecAttrKeyTypeECSECPrimeRandom, kSecAttrKeyClassPrivate)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +77,7 @@ func ECDH(priv *PrivateKeyECDH, pub *PublicKeyECDH) ([]byte, error) {
 	defer runtime.KeepAlive(priv)
 	defer runtime.KeepAlive(pub)
 
-	var algorithm C.CFStringRef = C.kSecKeyAlgorithmECDHKeyExchangeStandard
+	var algorithm C.CFStringRef = kSecKeyAlgorithmECDHKeyExchangeStandard
 
 	supported := C.SecKeyIsAlgorithmSupported(priv._pkey, C.kSecKeyOperationTypeKeyExchange, algorithm)
 	if supported == 0 {
@@ -109,7 +109,7 @@ func GenerateKeyECDH(curve string) (*PrivateKeyECDH, []byte, error) {
 	}
 	keySizeInBits := curveToKeySizeInBits(curve)
 	// Generate the private key and get its DER representation
-	privKeyDER, privKeyRef, err := createSecKeyRandom(C.kSecAttrKeyTypeECSECPrimeRandom, keySizeInBits)
+	privKeyDER, privKeyRef, err := createSecKeyRandom(kSecAttrKeyTypeECSECPrimeRandom, keySizeInBits)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/xcrypto/ecdsa.go
+++ b/xcrypto/ecdsa.go
@@ -52,7 +52,7 @@ func NewPublicKeyECDSA(curve string, x, y BigInt) (*PublicKeyECDSA, error) {
 		return nil, errors.New("failed to encode public key to uncompressed ANSI X9.63 format")
 	}
 
-	pubKeyRef, err := createSecKeyWithData(encodedKey, C.kSecAttrKeyTypeECSECPrimeRandom, C.kSecAttrKeyClassPublic)
+	pubKeyRef, err := createSecKeyWithData(encodedKey, kSecAttrKeyTypeECSECPrimeRandom, kSecAttrKeyClassPublic)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +73,7 @@ func NewPrivateKeyECDSA(curve string, x, y, d BigInt) (*PrivateKeyECDSA, error) 
 		return nil, errors.New("crypto/ecdsa: failed to encode private key: " + err.Error())
 	}
 
-	privKeyRef, err := createSecKeyWithData(encodedKey, C.kSecAttrKeyTypeECSECPrimeRandom, C.kSecAttrKeyClassPrivate)
+	privKeyRef, err := createSecKeyWithData(encodedKey, kSecAttrKeyTypeECSECPrimeRandom, kSecAttrKeyClassPrivate)
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +91,7 @@ func GenerateKeyECDSA(curve string) (x, y, d BigInt, err error) {
 	}
 
 	keySizeInBits := curveToKeySizeInBits(curve)
-	privKeyDER, privKeyRef, err := createSecKeyRandom(C.kSecAttrKeyTypeECSECPrimeRandom, keySizeInBits)
+	privKeyDER, privKeyRef, err := createSecKeyRandom(kSecAttrKeyTypeECSECPrimeRandom, keySizeInBits)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/xcrypto/evp.go
+++ b/xcrypto/evp.go
@@ -190,56 +190,56 @@ func selectAlgorithm(hash crypto.Hash, algorithmType algorithmType) (C.CFStringR
 	case algorithmTypePSS:
 		switch hash {
 		case crypto.SHA1:
-			algo = C.kSecKeyAlgorithmRSASignatureDigestPSSSHA1
+			algo = kSecKeyAlgorithmRSASignatureDigestPSSSHA1
 		case crypto.SHA224:
-			algo = C.kSecKeyAlgorithmRSASignatureDigestPSSSHA224
+			algo = kSecKeyAlgorithmRSASignatureDigestPSSSHA224
 		case crypto.SHA256:
-			algo = C.kSecKeyAlgorithmRSASignatureDigestPSSSHA256
+			algo = kSecKeyAlgorithmRSASignatureDigestPSSSHA256
 		case crypto.SHA384:
-			algo = C.kSecKeyAlgorithmRSASignatureDigestPSSSHA384
+			algo = kSecKeyAlgorithmRSASignatureDigestPSSSHA384
 		case crypto.SHA512:
-			algo = C.kSecKeyAlgorithmRSASignatureDigestPSSSHA512
+			algo = kSecKeyAlgorithmRSASignatureDigestPSSSHA512
 		default:
 			return 0, errors.New("unsupported PSS hash: " + hash.String())
 		}
 	case algorithmTypeRAW:
-		algo = C.kSecKeyAlgorithmRSAEncryptionRaw
+		algo = kSecKeyAlgorithmRSAEncryptionRaw
 	case algorithmTypePKCS1v15Enc:
-		return C.kSecKeyAlgorithmRSAEncryptionPKCS1, nil
+		return kSecKeyAlgorithmRSAEncryptionPKCS1, nil
 	case algorithmTypePKCS1v15Sig:
 		switch hash {
 		case crypto.SHA1:
-			algo = C.kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA1
+			algo = kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA1
 		case crypto.SHA224:
-			algo = C.kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA224
+			algo = kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA224
 		case crypto.SHA256:
-			algo = C.kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA256
+			algo = kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA256
 		case crypto.SHA384:
-			algo = C.kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA384
+			algo = kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA384
 		case crypto.SHA512:
-			algo = C.kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA512
+			algo = kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA512
 		case 0:
-			algo = C.kSecKeyAlgorithmRSASignatureDigestPKCS1v15Raw
+			algo = kSecKeyAlgorithmRSASignatureDigestPKCS1v15Raw
 		default:
 			return 0, errors.New("unsupported PKCS1v15 hash: " + hash.String())
 		}
 	case algorithmTypeOAEP:
 		switch hash {
 		case crypto.SHA1:
-			algo = C.kSecKeyAlgorithmRSAEncryptionOAEPSHA1
+			algo = kSecKeyAlgorithmRSAEncryptionOAEPSHA1
 		case crypto.SHA224:
-			algo = C.kSecKeyAlgorithmRSAEncryptionOAEPSHA224
+			algo = kSecKeyAlgorithmRSAEncryptionOAEPSHA224
 		case crypto.SHA256:
-			algo = C.kSecKeyAlgorithmRSAEncryptionOAEPSHA256
+			algo = kSecKeyAlgorithmRSAEncryptionOAEPSHA256
 		case crypto.SHA384:
-			algo = C.kSecKeyAlgorithmRSAEncryptionOAEPSHA384
+			algo = kSecKeyAlgorithmRSAEncryptionOAEPSHA384
 		case crypto.SHA512:
-			algo = C.kSecKeyAlgorithmRSAEncryptionOAEPSHA512
+			algo = kSecKeyAlgorithmRSAEncryptionOAEPSHA512
 		default:
 			return 0, errors.New("unsupported OAEP hash: " + hash.String())
 		}
 	case algorithmTypeECDSA:
-		return C.kSecKeyAlgorithmECDSASignatureDigestX962, nil
+		return kSecKeyAlgorithmECDSASignatureDigestX962, nil
 	default:
 		return 0, errors.New("unsupported algorithm type: " + strconv.Itoa(int(algorithmType)))
 	}
@@ -249,7 +249,7 @@ func selectAlgorithm(hash crypto.Hash, algorithmType algorithmType) (C.CFStringR
 // bytesToCFData turns a byte slice into a CFDataRef. Caller then "owns" the
 // CFDataRef and must CFRelease the CFDataRef when done.
 func bytesToCFData(buf []byte) C.CFDataRef {
-	return C.CFDataCreate(C.kCFAllocatorDefault, base(buf), C.CFIndex(len(buf)))
+	return C.CFDataCreate(kCFAllocatorDefault, base(buf), C.CFIndex(len(buf)))
 }
 
 // cfDataToBytes turns a CFDataRef into a byte slice.
@@ -264,15 +264,15 @@ func cfRelease(ref unsafe.Pointer) {
 
 // createSecKeyWithData creates a SecKey from the provided encoded key and attributes dictionary.
 func createSecKeyWithData(encodedKey []byte, keyType, keyClass C.CFStringRef) (C.SecKeyRef, error) {
-	encodedKeyCF := C.CFDataCreate(C.kCFAllocatorDefault, base(encodedKey), C.CFIndex(len(encodedKey)))
+	encodedKeyCF := C.CFDataCreate(kCFAllocatorDefault, base(encodedKey), C.CFIndex(len(encodedKey)))
 	if encodedKeyCF == 0 {
 		return 0, errors.New("xcrypto: failed to create CFData for private key")
 	}
 	defer C.CFRelease(C.CFTypeRef(encodedKeyCF))
 
 	attrKeys := []C.CFTypeRef{
-		C.CFTypeRef(C.kSecAttrKeyType),
-		C.CFTypeRef(C.kSecAttrKeyClass),
+		C.CFTypeRef(kSecAttrKeyType),
+		C.CFTypeRef(kSecAttrKeyClass),
 	}
 
 	attrValues := []C.CFTypeRef{
@@ -282,7 +282,7 @@ func createSecKeyWithData(encodedKey []byte, keyType, keyClass C.CFStringRef) (C
 
 	// Create attributes dictionary for the key
 	attrDict := C.CFDictionaryCreate(
-		C.kCFAllocatorDefault,
+		kCFAllocatorDefault,
 		(*unsafe.Pointer)(unsafe.Pointer(&attrKeys[0])),
 		(*unsafe.Pointer)(unsafe.Pointer(&attrValues[0])),
 		C.CFIndex(len(attrKeys)),
@@ -305,7 +305,7 @@ func createSecKeyWithData(encodedKey []byte, keyType, keyClass C.CFStringRef) (C
 
 // createSecKeyRandom creates a new SecKey with the provided attributes dictionary.
 func createSecKeyRandom(keyType C.CFStringRef, keySize int) ([]byte, C.SecKeyRef, error) {
-	keyAttrs := C.CFDictionaryCreateMutable(C.kCFAllocatorDefault, 0, nil, nil)
+	keyAttrs := C.CFDictionaryCreateMutable(kCFAllocatorDefault, 0, nil, nil)
 	if keyAttrs == 0 {
 		return nil, 0, errors.New("failed to create key attributes dictionary")
 	}
@@ -313,14 +313,14 @@ func createSecKeyRandom(keyType C.CFStringRef, keySize int) ([]byte, C.SecKeyRef
 
 	C.CFDictionarySetValue(
 		keyAttrs,
-		unsafe.Pointer(C.kSecAttrKeyType),
+		unsafe.Pointer(kSecAttrKeyType),
 		unsafe.Pointer(keyType),
 	)
 
 	C.CFDictionarySetValue(
 		keyAttrs,
-		unsafe.Pointer(C.kSecAttrKeySizeInBits),
-		unsafe.Pointer(C.CFNumberCreate(C.kCFAllocatorDefault, C.kCFNumberIntType, unsafe.Pointer(&keySize))),
+		unsafe.Pointer(kSecAttrKeySizeInBits),
+		unsafe.Pointer(C.CFNumberCreate(kCFAllocatorDefault, C.kCFNumberIntType, unsafe.Pointer(&keySize))),
 	)
 
 	// Generate the private key

--- a/xcrypto/rand.go
+++ b/xcrypto/rand.go
@@ -17,7 +17,7 @@ type randReader int
 func (randReader) Read(b []byte) (int, error) {
 	// Note: RAND_bytes should never fail; the return value exists only for historical reasons.
 	// We check it even so.
-	if len(b) > 0 && C.SecRandomCopyBytes(C.kSecRandomDefault, C.size_t(len(b)), unsafe.Pointer(&b[0])) != 0 {
+	if len(b) > 0 && C.SecRandomCopyBytes(nil, C.size_t(len(b)), unsafe.Pointer(&b[0])) != 0 {
 		return 0, errors.New("crypto/rand: unable to read from source")
 	}
 	return len(b), nil

--- a/xcrypto/rsa.go
+++ b/xcrypto/rsa.go
@@ -18,7 +18,7 @@ import (
 // GenerateKeyRSA generates an RSA key pair on macOS.
 // asn1Data is encoded as PKCS#1 ASN1 DER.
 func GenerateKeyRSA(bits int) (asn1Data []byte, err error) {
-	privKeyDER, privKeyRef, err := createSecKeyRandom(C.kSecAttrKeyTypeRSA, bits)
+	privKeyDER, privKeyRef, err := createSecKeyRandom(kSecAttrKeyTypeRSA, bits)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +39,7 @@ func (k *PublicKeyRSA) finalize() {
 
 // NewPublicKeyRSA creates a new RSA public key from ASN1 DER encoded data.
 func NewPublicKeyRSA(asn1Data []byte) (*PublicKeyRSA, error) {
-	pubKeyRef, err := createSecKeyWithData(asn1Data, C.kSecAttrKeyTypeRSA, C.kSecAttrKeyClassPublic)
+	pubKeyRef, err := createSecKeyWithData(asn1Data, kSecAttrKeyTypeRSA, kSecAttrKeyClassPublic)
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +70,7 @@ func (k *PrivateKeyRSA) finalize() {
 
 // NewPrivateKeyRSA creates a new RSA private key from ASN1 DER encoded data.
 func NewPrivateKeyRSA(asn1Data []byte) (*PrivateKeyRSA, error) {
-	privKeyRef, err := createSecKeyWithData(asn1Data, C.kSecAttrKeyTypeRSA, C.kSecAttrKeyClassPrivate)
+	privKeyRef, err := createSecKeyWithData(asn1Data, kSecAttrKeyTypeRSA, kSecAttrKeyClassPrivate)
 	if err != nil {
 		return nil, err
 	}

--- a/xcrypto/xcrypto.go
+++ b/xcrypto/xcrypto.go
@@ -7,8 +7,12 @@ package xcrypto
 
 // #cgo CFLAGS: -Wno-deprecated-declarations
 // #cgo LDFLAGS: -framework Security -framework CoreFoundation
+// #include <CoreFoundation/CFString.h>
 import "C"
-import "unsafe"
+import (
+	"runtime"
+	"unsafe"
+)
 
 // noescape hides a pointer from escape analysis. noescape is
 // the identity function but escape analysis doesn't think the
@@ -58,3 +62,63 @@ func pbase(b []byte) unsafe.Pointer {
 	}
 	return unsafe.Pointer(&b[0])
 }
+
+const kCFAllocatorDefault = 0
+const kCFStringEncodingUTF8 = 0x08000100
+
+func stringToCFString(s string) C.CFStringRef {
+	p := unsafe.Pointer(unsafe.StringData(s))
+	ret := C.CFStringCreateWithBytes(kCFAllocatorDefault, (*C.uint8_t)(p), C.CFIndex(len(s)), kCFStringEncodingUTF8, 0)
+	runtime.KeepAlive(p)
+	return C.CFStringRef(ret)
+}
+
+// Dictionary keys are defined as build-time strings with CFSTR, but the Go
+// linker's internal linking mode can't handle CFSTR relocations. Create our
+// own dynamic strings instead and just never release them.
+//
+// Note that this might be the only thing that can break over time if
+// these values change, as the ABI arguably requires using the strings
+// pointed to by the symbols, not values that happen to be equal to them.
+//
+// Values taken from:
+//   - https://github.com/apple-open-source-mirror/Security/blob/70c059a4fd48e34d6a3a2578be3e86d781753b19/OSX/sec/Security/SecItemConstants.c
+//   - https://github.com/apple-open-source-mirror/Security/blob/70c059a4fd48e34d6a3a2578be3e86d781753b19/OSX/sec/Security/SecKeyAdaptors.m
+var (
+	kSecAttrKeyClass      = stringToCFString("kcls")
+	kSecAttrKeySizeInBits = stringToCFString("bsiz")
+	kSecAttrKeyType       = stringToCFString("type")
+
+	kSecAttrKeyTypeRSA              = stringToCFString("42")
+	kSecAttrKeyTypeECSECPrimeRandom = stringToCFString("73")
+
+	kSecAttrKeyClassPublic  = stringToCFString("0")
+	kSecAttrKeyClassPrivate = stringToCFString("1")
+
+	kSecKeyAlgorithmECDHKeyExchangeStandard = stringToCFString("algid:keyexchange:ECDH")
+
+	kSecKeyAlgorithmECDSASignatureDigestX962 = stringToCFString("algid:sign:ECDSA:digest-X962")
+
+	kSecKeyAlgorithmRSAEncryptionPKCS1 = stringToCFString("algid:encrypt:RSA:PKCS1")
+	kSecKeyAlgorithmRSAEncryptionRaw   = stringToCFString("algid:encrypt:RSA:raw")
+
+	kSecKeyAlgorithmRSAEncryptionOAEPSHA1   = stringToCFString("algid:encrypt:RSA:OAEP:SHA1")
+	kSecKeyAlgorithmRSAEncryptionOAEPSHA224 = stringToCFString("algid:encrypt:RSA:OAEP:SHA224")
+	kSecKeyAlgorithmRSAEncryptionOAEPSHA256 = stringToCFString("algid:encrypt:RSA:OAEP:SHA256")
+	kSecKeyAlgorithmRSAEncryptionOAEPSHA384 = stringToCFString("algid:encrypt:RSA:OAEP:SHA384")
+	kSecKeyAlgorithmRSAEncryptionOAEPSHA512 = stringToCFString("algid:encrypt:RSA:OAEP:SHA512")
+
+	kSecKeyAlgorithmRSASignatureDigestPKCS1v15Raw    = stringToCFString("algid:sign:RSA:digest-PKCS1v15")
+	kSecKeyAlgorithmRSASignatureDigestPKCS1v15MD5    = stringToCFString("algid:sign:RSA:digest-PKCS1v15:MD5")
+	kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA1   = stringToCFString("algid:sign:RSA:digest-PKCS1v15:SHA1")
+	kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA224 = stringToCFString("algid:sign:RSA:digest-PKCS1v15:SHA224")
+	kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA256 = stringToCFString("algid:sign:RSA:digest-PKCS1v15:SHA256")
+	kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA384 = stringToCFString("algid:sign:RSA:digest-PKCS1v15:SHA384")
+	kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA512 = stringToCFString("algid:sign:RSA:digest-PKCS1v15:SHA512")
+
+	kSecKeyAlgorithmRSASignatureDigestPSSSHA1   = stringToCFString("algid:sign:RSA:digest-PSS:SHA1:SHA1:20")
+	kSecKeyAlgorithmRSASignatureDigestPSSSHA224 = stringToCFString("algid:sign:RSA:digest-PSS:SHA224:SHA224:24")
+	kSecKeyAlgorithmRSASignatureDigestPSSSHA256 = stringToCFString("algid:sign:RSA:digest-PSS:SHA256:SHA256:32")
+	kSecKeyAlgorithmRSASignatureDigestPSSSHA384 = stringToCFString("algid:sign:RSA:digest-PSS:SHA384:SHA384:48")
+	kSecKeyAlgorithmRSASignatureDigestPSSSHA512 = stringToCFString("algid:sign:RSA:digest-PSS:SHA512:SHA512:64")
+)


### PR DESCRIPTION
Dictionary keys are defined as build-time strings with CFSTR, but the Go linker's internal linking mode can't handle CFSTR relocations. Create our own dynamic strings instead and just never release them.

Approach taken from the Go standard library, which also was this issue when calling Darwin functions.

This PR still doesn't fix internal linking.

For #33.