### PR TITLE
Make one-shot hash functions not to allocate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,25 +13,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.22.x, 1.23.x]
+        go-version: [1.23.x, 1.24.x]
         macos-version: [macos-13, macos-14, macos-15]
     runs-on: ${{ matrix.macos-version }}
     steps:
-        - uses: actions/setup-go@v5
-          with:
-            go-version: ${{ matrix.go-version }}
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
 
-        - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-        - name: Build CryptoKit.o
-          run: bash gen-swift-bindings.sh
+      - name: Build CryptoKit.o
+        run: bash gen-swift-bindings.sh
 
-        - name: Run Go Tests
-          run: go test -gcflags=all=-d=checkptr -count 10 -v ./...
+      - name: Run Go Tests
+        run: go test -gcflags=all=-d=checkptr -count 10 -v ./...
 
-        - name: Run Swift Tests
-          working-directory: cryptokit
-          run: swift test
+      - name: Run Swift Tests
+        working-directory: cryptokit
+        run: swift test
   santise:
     runs-on: ubuntu-latest
     steps:

--- a/internal/cryptokit/cgo_go124.go
+++ b/internal/cryptokit/cgo_go124.go
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//go:build go1.24 && darwin
+
+package cryptokit
+
+// See xcrypto/cgo_go124.go for context.
+
+/*
+#cgo noescape MD5
+#cgo nocallback MD5
+#cgo noescape SHA1
+#cgo nocallback SHA1
+#cgo noescape SHA256
+#cgo nocallback SHA256
+#cgo noescape SHA384
+#cgo nocallback SHA384
+#cgo noescape SHA512
+#cgo nocallback SHA512
+*/
+import "C"

--- a/internal/cryptokit/hash.go
+++ b/internal/cryptokit/hash.go
@@ -15,10 +15,7 @@ func MD5(p []byte) (sum [16]byte) {
 		pinner.Pin(&p[0])
 		defer pinner.Unpin()
 	}
-	C.MD5(
-		base(p),
-		C.size_t(len(p)),
-		base(sum[:]))
+	C.MD5(base(p), C.size_t(len(p)), base(sum[:]))
 	return
 }
 
@@ -28,10 +25,7 @@ func SHA1(p []byte) (sum [20]byte) {
 		pinner.Pin(&p[0])
 		defer pinner.Unpin()
 	}
-	C.SHA1(
-		base(p),
-		C.size_t(len(p)),
-		base(sum[:]))
+	C.SHA1(base(p), C.size_t(len(p)), base(sum[:]))
 	return
 }
 
@@ -41,10 +35,7 @@ func SHA256(p []byte) (sum [32]byte) {
 		pinner.Pin(&p[0])
 		defer pinner.Unpin()
 	}
-	C.SHA256(
-		base(p),
-		C.size_t(len(p)),
-		base(sum[:]))
+	C.SHA256(base(p), C.size_t(len(p)), base(sum[:]))
 	return
 }
 
@@ -54,10 +45,7 @@ func SHA384(p []byte) (sum [48]byte) {
 		pinner.Pin(&p[0])
 		defer pinner.Unpin()
 	}
-	C.SHA384(
-		base(p),
-		C.size_t(len(p)),
-		base(sum[:]))
+	C.SHA384(base(p), C.size_t(len(p)), base(sum[:]))
 	return
 }
 
@@ -67,9 +55,6 @@ func SHA512(p []byte) (sum [64]byte) {
 		pinner.Pin(&p[0])
 		defer pinner.Unpin()
 	}
-	C.SHA512(
-		base(p),
-		C.size_t(len(p)),
-		base(sum[:]))
+	C.SHA512(base(p), C.size_t(len(p)), base(sum[:]))
 	return
 }

--- a/internal/cryptokit/hash.go
+++ b/internal/cryptokit/hash.go
@@ -7,44 +7,69 @@ package cryptokit
 
 // #include "cryptokit.h"
 import "C"
-import "unsafe"
+import "runtime"
 
 func MD5(p []byte) (sum [16]byte) {
+	if len(p) > 0 {
+		var pinner runtime.Pinner
+		pinner.Pin(&p[0])
+		defer pinner.Unpin()
+	}
 	C.MD5(
 		base(p),
 		C.size_t(len(p)),
-		(*C.uint8_t)(unsafe.Pointer(&sum[0])))
+		base(sum[:]))
 	return
 }
 
 func SHA1(p []byte) (sum [20]byte) {
+	if len(p) > 0 {
+		var pinner runtime.Pinner
+		pinner.Pin(&p[0])
+		defer pinner.Unpin()
+	}
 	C.SHA1(
 		base(p),
 		C.size_t(len(p)),
-		(*C.uint8_t)(unsafe.Pointer(&sum[0])))
+		base(sum[:]))
 	return
 }
 
 func SHA256(p []byte) (sum [32]byte) {
+	if len(p) > 0 {
+		var pinner runtime.Pinner
+		pinner.Pin(&p[0])
+		defer pinner.Unpin()
+	}
 	C.SHA256(
 		base(p),
 		C.size_t(len(p)),
-		(*C.uint8_t)(unsafe.Pointer(&sum[0])))
+		base(sum[:]))
 	return
 }
 
 func SHA384(p []byte) (sum [48]byte) {
+	if len(p) > 0 {
+		var pinner runtime.Pinner
+		pinner.Pin(&p[0])
+		defer pinner.Unpin()
+	}
 	C.SHA384(
 		base(p),
 		C.size_t(len(p)),
-		(*C.uint8_t)(unsafe.Pointer(&sum[0])))
+		base(sum[:]))
 	return
 }
 
 func SHA512(p []byte) (sum [64]byte) {
+	if len(p) > 0 {
+		var pinner runtime.Pinner
+		pinner.Pin(&p[0])
+		defer pinner.Unpin()
+	}
 	C.SHA512(
 		base(p),
 		C.size_t(len(p)),
-		(*C.uint8_t)(unsafe.Pointer(&sum[0])))
+		base(sum[:]))
 	return
 }

--- a/xcrypto/asan_disabled_test.go
+++ b/xcrypto/asan_disabled_test.go
@@ -1,0 +1,7 @@
+//go:build !asan
+
+package xcrypto_test
+
+func Asan() bool {
+	return false
+}

--- a/xcrypto/asan_enabled_test.go
+++ b/xcrypto/asan_enabled_test.go
@@ -1,0 +1,7 @@
+//go:build asan
+
+package xcrypto_test
+
+func Asan() bool {
+	return true
+}

--- a/xcrypto/cgo_go124.go
+++ b/xcrypto/cgo_go124.go
@@ -16,6 +16,12 @@ package xcrypto
 // observed to benefit from these directives, not every function that is merely
 // expected to meet the noescape/nocallback criteria.
 
-// #cgo noescape SecRandomCopyBytes
-// #cgo nocallback SecRandomCopyBytes
+/*
+#cgo noescape SecRandomCopyBytes
+#cgo nocallback SecRandomCopyBytes
+#cgo noescape CC_MD4
+#cgo nocallback CC_MD4
+#cgo noescape CC_SHA224
+#cgo nocallback CC_SHA224
+*/
 import "C"

--- a/xcrypto/hash.go
+++ b/xcrypto/hash.go
@@ -149,9 +149,9 @@ func (h *evpHash) Reset() {
 
 func (h *evpHash) Write(p []byte) (int, error) {
 	h.initialize()
-	defer h.pinner.Unpin()
-	h.pinner.Pin(&p[0])
 	if len(p) > 0 {
+		defer h.pinner.Unpin()
+		h.pinner.Pin(&p[0])
 		// Use a local variable to prevent the compiler from misinterpreting the pointer
 		data := p
 		if h.update(h.ctx, data) != 1 {

--- a/xcrypto/hash.go
+++ b/xcrypto/hash.go
@@ -17,17 +17,6 @@ import (
 	"github.com/microsoft/go-crypto-darwin/internal/cryptokit"
 )
 
-// NOTE: Implementation ported from https://go-review.googlesource.com/c/go/+/404295.
-// The cgo calls in this file are arranged to avoid marking the parameters as escaping.
-// To do that, we call noescape (including via addr).
-// We must also make sure that the data pointer arguments have the form unsafe.Pointer(&...)
-// so that cgo does not annotate them with cgoCheckPointer calls. If it did that, it might look
-// beyond the byte slice and find Go pointers in unprocessed parts of a larger allocation.
-// To do both of these simultaneously, the idiom is unsafe.Pointer(&*addr(p)),
-// where addr returns the base pointer of p, substituting a non-nil pointer for nil,
-// and applying a noescape along the way.
-// This is all to preserve compatibility with the allocation behavior of the non-commoncrypto implementations.
-
 // SupportsHash returns true if a hash.Hash implementation is supported for h.
 func SupportsHash(h crypto.Hash) bool {
 	switch h {
@@ -39,7 +28,12 @@ func SupportsHash(h crypto.Hash) bool {
 }
 
 func MD4(p []byte) (sum [16]byte) {
-	result := C.CC_MD4(unsafe.Pointer(&*addr(p)), C.CC_LONG(len(p)), (*C.uchar)(&*addr(sum[:])))
+	if len(p) > 0 {
+		var pinner runtime.Pinner
+		defer pinner.Unpin()
+		pinner.Pin(&p[0])
+	}
+	result := C.CC_MD4(pbase(p), C.CC_LONG(len(p)), base(sum[:]))
 	if result == nil {
 		panic("commoncrypto: MD4 failed")
 	}
@@ -55,7 +49,12 @@ func SHA1(p []byte) (sum [20]byte) {
 }
 
 func SHA224(p []byte) (sum [28]byte) {
-	result := C.CC_SHA224(unsafe.Pointer(&*addr(p)), C.CC_LONG(len(p)), (*C.uchar)(&*addr(sum[:])))
+	if len(p) > 0 {
+		var pinner runtime.Pinner
+		defer pinner.Unpin()
+		pinner.Pin(&p[0])
+	}
+	result := C.CC_SHA224(pbase(p), C.CC_LONG(len(p)), base(sum[:]))
 	if result == nil {
 		panic("commoncrypto: SHA224 failed")
 	}
@@ -94,6 +93,7 @@ type evpHash struct {
 	// the state of ctx. Having it here allows reusing the
 	// same allocated object multiple times.
 	ctx2      unsafe.Pointer
+	pinner    runtime.Pinner
 	init      func(ctx unsafe.Pointer) C.int
 	update    func(ctx unsafe.Pointer, data []byte) C.int
 	final     func(ctx unsafe.Pointer, digest []byte) C.int
@@ -149,6 +149,8 @@ func (h *evpHash) Reset() {
 
 func (h *evpHash) Write(p []byte) (int, error) {
 	h.initialize()
+	defer h.pinner.Unpin()
+	h.pinner.Pin(&p[0])
 	if len(p) > 0 {
 		// Use a local variable to prevent the compiler from misinterpreting the pointer
 		data := p
@@ -240,7 +242,7 @@ func NewMD4() hash.Hash {
 		evpHash: newEvpHash(
 			func(ctx unsafe.Pointer) C.int { return C.CC_MD4_Init((*C.CC_MD4_CTX)(ctx)) },
 			func(ctx unsafe.Pointer, data []byte) C.int {
-				return C.CC_MD4_Update((*C.CC_MD4_CTX)(ctx), unsafe.Pointer(&*addr(data)), C.CC_LONG(len(data)))
+				return C.CC_MD4_Update((*C.CC_MD4_CTX)(ctx), pbase(data), C.CC_LONG(len(data)))
 			},
 			func(ctx unsafe.Pointer, digest []byte) C.int {
 				return C.CC_MD4_Final(base(digest), (*C.CC_MD4_CTX)(ctx))
@@ -262,7 +264,7 @@ func NewMD5() hash.Hash {
 		evpHash: newEvpHash(
 			func(ctx unsafe.Pointer) C.int { return C.CC_MD5_Init((*C.CC_MD5_CTX)(ctx)) },
 			func(ctx unsafe.Pointer, data []byte) C.int {
-				return C.CC_MD5_Update((*C.CC_MD5_CTX)(ctx), unsafe.Pointer(&*addr(data)), C.CC_LONG(len(data)))
+				return C.CC_MD5_Update((*C.CC_MD5_CTX)(ctx), pbase(data), C.CC_LONG(len(data)))
 			},
 			func(ctx unsafe.Pointer, digest []byte) C.int {
 				return C.CC_MD5_Final(base(digest), (*C.CC_MD5_CTX)(ctx))
@@ -284,7 +286,7 @@ func NewSHA1() hash.Hash {
 		evpHash: newEvpHash(
 			func(ctx unsafe.Pointer) C.int { return C.CC_SHA1_Init((*C.CC_SHA1_CTX)(ctx)) },
 			func(ctx unsafe.Pointer, data []byte) C.int {
-				return C.CC_SHA1_Update((*C.CC_SHA1_CTX)(ctx), unsafe.Pointer(&*addr(data)), C.CC_LONG(len(data)))
+				return C.CC_SHA1_Update((*C.CC_SHA1_CTX)(ctx), pbase(data), C.CC_LONG(len(data)))
 			},
 			func(ctx unsafe.Pointer, digest []byte) C.int {
 				return C.CC_SHA1_Final(base(digest), (*C.CC_SHA1_CTX)(ctx))
@@ -306,7 +308,7 @@ func NewSHA224() hash.Hash {
 		evpHash: newEvpHash(
 			func(ctx unsafe.Pointer) C.int { return C.CC_SHA224_Init((*C.CC_SHA256_CTX)(ctx)) },
 			func(ctx unsafe.Pointer, data []byte) C.int {
-				return C.CC_SHA224_Update((*C.CC_SHA256_CTX)(ctx), unsafe.Pointer(&*addr(data)), C.CC_LONG(len(data)))
+				return C.CC_SHA224_Update((*C.CC_SHA256_CTX)(ctx), pbase(data), C.CC_LONG(len(data)))
 			},
 			func(ctx unsafe.Pointer, digest []byte) C.int {
 				return C.CC_SHA224_Final(base(digest), (*C.CC_SHA256_CTX)(ctx))
@@ -328,7 +330,7 @@ func NewSHA256() hash.Hash {
 		evpHash: newEvpHash(
 			func(ctx unsafe.Pointer) C.int { return C.CC_SHA256_Init((*C.CC_SHA256_CTX)(ctx)) },
 			func(ctx unsafe.Pointer, data []byte) C.int {
-				return C.CC_SHA256_Update((*C.CC_SHA256_CTX)(ctx), unsafe.Pointer(&*addr(data)), C.CC_LONG(len(data)))
+				return C.CC_SHA256_Update((*C.CC_SHA256_CTX)(ctx), pbase(data), C.CC_LONG(len(data)))
 			},
 			func(ctx unsafe.Pointer, digest []byte) C.int {
 				return C.CC_SHA256_Final(base(digest), (*C.CC_SHA256_CTX)(ctx))
@@ -350,7 +352,7 @@ func NewSHA384() hash.Hash {
 		evpHash: newEvpHash(
 			func(ctx unsafe.Pointer) C.int { return C.CC_SHA384_Init((*C.CC_SHA512_CTX)(ctx)) },
 			func(ctx unsafe.Pointer, data []byte) C.int {
-				return C.CC_SHA384_Update((*C.CC_SHA512_CTX)(ctx), unsafe.Pointer(&*addr(data)), C.CC_LONG(len(data)))
+				return C.CC_SHA384_Update((*C.CC_SHA512_CTX)(ctx), pbase(data), C.CC_LONG(len(data)))
 			},
 			func(ctx unsafe.Pointer, digest []byte) C.int {
 				return C.CC_SHA384_Final(base(digest), (*C.CC_SHA512_CTX)(ctx))
@@ -372,7 +374,7 @@ func NewSHA512() hash.Hash {
 		evpHash: newEvpHash(
 			func(ctx unsafe.Pointer) C.int { return C.CC_SHA512_Init((*C.CC_SHA512_CTX)(ctx)) },
 			func(ctx unsafe.Pointer, data []byte) C.int {
-				return C.CC_SHA512_Update((*C.CC_SHA512_CTX)(ctx), unsafe.Pointer(&*addr(data)), C.CC_LONG(len(data)))
+				return C.CC_SHA512_Update((*C.CC_SHA512_CTX)(ctx), pbase(data), C.CC_LONG(len(data)))
 			},
 			func(ctx unsafe.Pointer, digest []byte) C.int {
 				return C.CC_SHA512_Final(base(digest), (*C.CC_SHA512_CTX)(ctx))

--- a/xcrypto/hmac.go
+++ b/xcrypto/hmac.go
@@ -12,7 +12,6 @@ import (
 	"hash"
 	"runtime"
 	"slices"
-	"unsafe"
 )
 
 // commonCryptoHMAC encapsulates an HMAC using xcrypto.
@@ -58,8 +57,11 @@ func NewHMAC(fh func() hash.Hash, key []byte) hash.Hash {
 // Write adds more data to the running HMAC hash.
 func (h *commonCryptoHMAC) Write(p []byte) (int, error) {
 	if len(p) > 0 {
-		C.CCHmacUpdate(&h.ctx, unsafe.Pointer(&*addr(p)), C.size_t(len(p)))
+		var pinner runtime.Pinner
+		pinner.Pin(&p[0])
+		defer pinner.Unpin()
 	}
+	C.CCHmacUpdate(&h.ctx, pbase(p), C.size_t(len(p)))
 	runtime.KeepAlive(h)
 	return len(p), nil
 }

--- a/xcrypto/hmac.go
+++ b/xcrypto/hmac.go
@@ -22,6 +22,7 @@ type commonCryptoHMAC struct {
 	output    []byte
 	size      int
 	blockSize int
+	pinner    runtime.Pinner
 }
 
 // NewHMAC returns a new HMAC using xcrypto.
@@ -57,9 +58,8 @@ func NewHMAC(fh func() hash.Hash, key []byte) hash.Hash {
 // Write adds more data to the running HMAC hash.
 func (h *commonCryptoHMAC) Write(p []byte) (int, error) {
 	if len(p) > 0 {
-		var pinner runtime.Pinner
-		pinner.Pin(&p[0])
-		defer pinner.Unpin()
+		h.pinner.Pin(&p[0])
+		defer h.pinner.Unpin()
 	}
 	C.CCHmacUpdate(&h.ctx, pbase(p), C.size_t(len(p)))
 	runtime.KeepAlive(h)

--- a/xcrypto/xcrypto.go
+++ b/xcrypto/xcrypto.go
@@ -10,31 +10,7 @@ package xcrypto
 import "C"
 import "unsafe"
 
-// noescape hides a pointer from escape analysis. noescape is
-// the identity function but escape analysis doesn't think the
-// output depends on the input. noescape is inlined and currently
-// compiles down to zero instructions.
-// USE CAREFULLY!
-//
-//go:nosplit
-func noescape(p unsafe.Pointer) unsafe.Pointer {
-	x := uintptr(p)
-	return unsafe.Pointer(x ^ 0)
-}
-
 var zero byte
-
-// addr converts p to its base addr, including a noescape along the way.
-// If p is nil, addr returns a non-nil pointer, so that the result can always
-// be dereferenced.
-//
-//go:nosplit
-func addr(p []byte) *byte {
-	if len(p) == 0 {
-		return &zero
-	}
-	return (*byte)(noescape(unsafe.Pointer(&p[0])))
-}
 
 // base returns the address of the underlying array in b,
 // being careful not to panic when b has zero length.


### PR DESCRIPTION
fixes: https://github.com/microsoft/go-crypto-darwin/issues/43

loosely based on https://github.com/golang-fips/openssl/pull/258