### PR TITLE
Fix HMAC and multiple use hash methods allocation

### DIFF
--- a/cryptokit/Sources/CryptoKitSrc/hash.swift
+++ b/cryptokit/Sources/CryptoKitSrc/hash.swift
@@ -69,297 +69,236 @@ public func SHA512(
     hashData.copyBytes(to: outputPointer, count: hashData.count)
 }
 
-@_cdecl("NewMD5")
-public func NewMD5() -> UnsafeMutableRawPointer {
-    let hasher = UnsafeMutablePointer<Insecure.MD5>.allocate(capacity: 1)
-    hasher.initialize(to: Insecure.MD5())
-    return UnsafeMutableRawPointer(hasher)
+@_cdecl("hashNew")
+public func hashNew(_ hashAlgorithm: Int32) -> UnsafeMutableRawPointer {
+    switch hashAlgorithm {
+    case 1:
+        let hasher = UnsafeMutablePointer<Insecure.MD5>.allocate(capacity: 1)
+        hasher.initialize(to: Insecure.MD5())
+        return UnsafeMutableRawPointer(hasher)
+    case 2:
+        let hasher = UnsafeMutablePointer<Insecure.SHA1>.allocate(capacity: 1)
+        hasher.initialize(to: Insecure.SHA1())
+        return UnsafeMutableRawPointer(hasher)
+    case 3:
+        let hasher = UnsafeMutablePointer<CryptoKit.SHA256>.allocate(capacity: 1)
+        hasher.initialize(to: CryptoKit.SHA256())
+        return UnsafeMutableRawPointer(hasher)
+    case 4:
+        let hasher = UnsafeMutablePointer<CryptoKit.SHA384>.allocate(capacity: 1)
+        hasher.initialize(to: CryptoKit.SHA384())
+        return UnsafeMutableRawPointer(hasher)
+    case 5:
+        let hasher = UnsafeMutablePointer<CryptoKit.SHA512>.allocate(capacity: 1)
+        hasher.initialize(to: CryptoKit.SHA512())
+        return UnsafeMutableRawPointer(hasher)
+    default:
+        fatalError("Unsupported hash function")
+    }
 }
 
-@_cdecl("MD5Write")
-public func MD5Write(_ ptr: UnsafeMutableRawPointer, _ data: UnsafePointer<UInt8>, _ length: Int) {
-    let hasher = ptr.assumingMemoryBound(to: Insecure.MD5.self)
-    let buffer = UnsafeRawBufferPointer(start: data, count: length)
+@_cdecl("hashWrite")
+public func hashWrite(
+    _ hashAlgorithm: Int32,
+    _ ptr: UnsafeMutableRawPointer,
+    _ data: UnsafePointer<UInt8>,
+    _ length: Int
+) {
+    switch hashAlgorithm {
+    case 1:
+        let hasher = ptr.assumingMemoryBound(to: Insecure.MD5.self)
+        let buffer = UnsafeRawBufferPointer(start: data, count: length)
+        hasher.pointee.update(data: buffer)
+    case 2:
+        let hasher = ptr.assumingMemoryBound(to: Insecure.SHA1.self)
+        let buffer = UnsafeRawBufferPointer(start: data, count: length)
+        hasher.pointee.update(data: buffer)
+    case 3:
+        let hasher = ptr.assumingMemoryBound(to: CryptoKit.SHA256.self)
+        let buffer = UnsafeRawBufferPointer(start: data, count: length)
+        hasher.pointee.update(data: buffer)
+    case 4:
+        let hasher = ptr.assumingMemoryBound(to: CryptoKit.SHA384.self)
+        let buffer = UnsafeRawBufferPointer(start: data, count: length)
+        hasher.pointee.update(data: buffer)
+    case 5:
+        let hasher = ptr.assumingMemoryBound(to: CryptoKit.SHA512.self)
+        let buffer = UnsafeRawBufferPointer(start: data, count: length)
+        hasher.pointee.update(data: buffer)
+    default:
+        fatalError("Unsupported hash function")
+    }
+}
+@_cdecl("hashSum")
+public func hashSum(
+    _ hashAlgorithm: Int32,
+    _ ptr: UnsafeMutableRawPointer,
+    _ outputPointer: UnsafeMutablePointer<UInt8>
+) {
+    switch hashAlgorithm {
+    case 1:
+        let hasher = ptr.assumingMemoryBound(to: Insecure.MD5.self)
+        let copiedHasher = hasher.pointee
+        let hash = copiedHasher.finalize();
 
-    hasher.pointee.update(data: buffer)
+        let hashData = hash.withUnsafeBytes { Data($0) }
+        hashData.copyBytes(to: outputPointer, count: hashData.count)
+    case 2:
+        let hasher = ptr.assumingMemoryBound(to: Insecure.SHA1.self)
+        let copiedHasher = hasher.pointee
+        let hash = copiedHasher.finalize();
 
-    // No need to return length as Swift doesn't have partial writes
+        let hashData = hash.withUnsafeBytes { Data($0) }
+        hashData.copyBytes(to: outputPointer, count: hashData.count)
+    case 3:
+        let hasher = ptr.assumingMemoryBound(to: CryptoKit.SHA256.self)
+        let copiedHasher = hasher.pointee
+        let hash = copiedHasher.finalize();
+
+        let hashData = hash.withUnsafeBytes { Data($0) }
+        hashData.copyBytes(to: outputPointer, count: hashData.count)
+    case 4:
+        let hasher = ptr.assumingMemoryBound(to: CryptoKit.SHA384.self)
+        let copiedHasher = hasher.pointee
+        let hash = copiedHasher.finalize();
+
+        let hashData = hash.withUnsafeBytes { Data($0) }
+        hashData.copyBytes(to: outputPointer, count: hashData.count)
+    case 5:
+        let hasher = ptr.assumingMemoryBound(to: CryptoKit.SHA512.self)
+        let copiedHasher = hasher.pointee
+        let hash = copiedHasher.finalize();
+
+        let hashData = hash.withUnsafeBytes { Data($0) }
+        hashData.copyBytes(to: outputPointer, count: hashData.count)
+    default:
+        fatalError("Unsupported hash function")
+    }
 }
 
-@_cdecl("MD5Sum")
-public func MD5Sum(_ ptr: UnsafeMutableRawPointer, _ outputPointer: UnsafeMutablePointer<UInt8>) {
-    let hasher = ptr.assumingMemoryBound(to: Insecure.MD5.self)
-    let copiedHasher = hasher.pointee
-    let hash = copiedHasher.finalize();
-
-    let hashData = hash.withUnsafeBytes { Data($0) }
-    hashData.copyBytes(to: outputPointer, count: hashData.count)
+@_cdecl("hashReset")
+public func hashReset(
+    _ hashAlgorithm: Int32,
+    _ ptr: UnsafeMutableRawPointer
+) {
+    switch hashAlgorithm {
+    case 1:
+        let hasher = ptr.assumingMemoryBound(to: Insecure.MD5.self)
+        hasher.pointee = Insecure.MD5()
+    case 2:
+        let hasher = ptr.assumingMemoryBound(to: Insecure.SHA1.self)
+        hasher.pointee = Insecure.SHA1()
+    case 3:
+        let hasher = ptr.assumingMemoryBound(to: CryptoKit.SHA256.self)
+        hasher.pointee = CryptoKit.SHA256()
+    case 4:
+        let hasher = ptr.assumingMemoryBound(to: CryptoKit.SHA384.self)
+        hasher.pointee = CryptoKit.SHA384()
+    case 5:
+        let hasher = ptr.assumingMemoryBound(to: CryptoKit.SHA512.self)
+        hasher.pointee = CryptoKit.SHA512()
+    default:
+        fatalError("Unsupported hash function")
+    }
 }
 
-@_cdecl("MD5Reset")
-public func MD5Reset(_ ptr: UnsafeMutableRawPointer) {
-    let hasher = ptr.assumingMemoryBound(to: Insecure.MD5.self)
-    hasher.pointee = Insecure.MD5()
+@_cdecl("hashSize")
+public func hashSize(_ hashAlgorithm: Int32) -> Int {
+    switch hashAlgorithm {
+    case 1:
+        return Insecure.MD5.byteCount
+    case 2:
+        return Insecure.SHA1.byteCount
+    case 3:
+        return CryptoKit.SHA256.byteCount
+    case 4:
+        return CryptoKit.SHA384.byteCount
+    case 5:
+        return CryptoKit.SHA512.byteCount
+    default:
+        fatalError("Unsupported hash function")
+    }
 }
 
-@_cdecl("MD5Size")
-public func MD5Size() -> Int {
-    return Insecure.MD5.byteCount
+@_cdecl("hashBlockSize")
+public func hashBlockSize(_ hashAlgorithm: Int32) -> Int {
+    switch hashAlgorithm {
+    case 1:
+        return Insecure.MD5.blockByteCount
+    case 2:
+        return Insecure.SHA1.blockByteCount
+    case 3:
+        return CryptoKit.SHA256.blockByteCount
+    case 4:
+        return CryptoKit.SHA384.blockByteCount
+    case 5:
+        return CryptoKit.SHA512.blockByteCount
+    default:
+        fatalError("Unsupported hash function")
+    }
+}
+@_cdecl("hashCopy")
+public func hashCopy(_ hashAlgorithm: Int32, _ ptr: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+    switch hashAlgorithm {
+    case 1:
+        let hasher = ptr.assumingMemoryBound(to: Insecure.MD5.self)
+        let copyOf = hasher.pointee
+        let newHasher = UnsafeMutablePointer<Insecure.MD5>.allocate(capacity: 1)
+        newHasher.initialize(to: copyOf)
+
+        return UnsafeMutableRawPointer(newHasher)
+    case 2:
+        let hasher = ptr.assumingMemoryBound(to: Insecure.SHA1.self)
+        let copyOf = hasher.pointee
+        let newHasher = UnsafeMutablePointer<Insecure.SHA1>.allocate(capacity: 1)
+        newHasher.initialize(to: copyOf)
+
+        return UnsafeMutableRawPointer(newHasher)
+    case 3:
+        let hasher = ptr.assumingMemoryBound(to: CryptoKit.SHA256.self)
+        let copyOf = hasher.pointee
+        let newHasher = UnsafeMutablePointer<CryptoKit.SHA256>.allocate(capacity: 1)
+        newHasher.initialize(to: copyOf)
+
+        return UnsafeMutableRawPointer(newHasher)
+    case 4:
+        let hasher = ptr.assumingMemoryBound(to: CryptoKit.SHA384.self)
+        let copyOf = hasher.pointee
+        let newHasher = UnsafeMutablePointer<CryptoKit.SHA384>.allocate(capacity: 1)
+        newHasher.initialize(to: copyOf)
+
+        return UnsafeMutableRawPointer(newHasher)
+    case 5:
+        let hasher = ptr.assumingMemoryBound(to: CryptoKit.SHA512.self)
+        let copyOf = hasher.pointee
+        let newHasher = UnsafeMutablePointer<CryptoKit.SHA512>.allocate(capacity: 1)
+        newHasher.initialize(to: copyOf)
+
+        return UnsafeMutableRawPointer(newHasher)
+    default:
+        fatalError("Unsupported hash function")
+    }
 }
 
-@_cdecl("MD5BlockSize")
-public func MD5BlockSize() -> Int {
-    return Insecure.MD5.blockByteCount
-}
-
-@_cdecl("MD5Copy")
-public func MD5Copy(_ ptr: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
-    let hasher = ptr.assumingMemoryBound(to: Insecure.MD5.self)
-    let copyOf = hasher.pointee
-    let newHasher = UnsafeMutablePointer<Insecure.MD5>.allocate(capacity: 1)
-    newHasher.initialize(to: copyOf)
-
-    return UnsafeMutableRawPointer(newHasher)
-}
-
-@_cdecl("MD5Free")
-public func MD5Free(_ ptr: UnsafeMutableRawPointer) {
-    let hasher = ptr.assumingMemoryBound(to: Insecure.MD5.self)
-    hasher.deallocate()
-}
-
-@_cdecl("NewSHA1")
-public func NewSHA1() -> UnsafeMutableRawPointer {
-    let hasher = UnsafeMutablePointer<Insecure.SHA1>.allocate(capacity: 1)
-    hasher.initialize(to: Insecure.SHA1())
-    return UnsafeMutableRawPointer(hasher)
-}
-
-@_cdecl("SHA1Write")
-public func SHA1Write(_ ptr: UnsafeMutableRawPointer, _ data: UnsafePointer<UInt8>, _ length: Int) {
-    let hasher = ptr.assumingMemoryBound(to: Insecure.SHA1.self)
-    let buffer = UnsafeRawBufferPointer(start: data, count: length)
-
-    hasher.pointee.update(data: buffer)
-
-    // No need to return length as Swift doesn't have partial writes
-}
-
-@_cdecl("SHA1Sum")
-public func SHA1Sum(_ ptr: UnsafeMutableRawPointer, _ outputPointer: UnsafeMutablePointer<UInt8>) {
-    let hasher = ptr.assumingMemoryBound(to: Insecure.SHA1.self)
-    let copiedHasher = hasher.pointee
-    let hash = copiedHasher.finalize();
-
-    let hashData = hash.withUnsafeBytes { Data($0) }
-    hashData.copyBytes(to: outputPointer, count: hashData.count)
-}
-
-@_cdecl("SHA1Reset")
-public func SHA1Reset(_ sha1Ptr: UnsafeMutableRawPointer) {
-    let hasher = sha1Ptr.assumingMemoryBound(to: Insecure.SHA1.self)
-    hasher.pointee = Insecure.SHA1()
-}
-
-@_cdecl("SHA1Size")
-public func SHA1Size() -> Int {
-    return Insecure.SHA1.byteCount
-}
-
-@_cdecl("SHA1BlockSize")
-public func SHA1BlockSize() -> Int {
-    return Insecure.SHA1.blockByteCount
-}
-
-@_cdecl("SHA1Copy")
-public func SHA1Copy(_ ptr: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
-    let hasher = ptr.assumingMemoryBound(to: Insecure.SHA1.self)
-    let copyOf = hasher.pointee
-    let newHasher = UnsafeMutablePointer<Insecure.SHA1>.allocate(capacity: 1)
-    newHasher.initialize(to: copyOf)
-
-    return UnsafeMutableRawPointer(newHasher)
-}
-
-@_cdecl("SHA1Free")
-public func SHA1Free(_ ptr: UnsafeMutableRawPointer) {
-    let hasher = ptr.assumingMemoryBound(to: Insecure.SHA1.self)
-    hasher.deallocate()
-}
-
-@_cdecl("NewSHA256")
-public func NewSHA256() -> UnsafeMutableRawPointer {
-    let hasher = UnsafeMutablePointer<CryptoKit.SHA256>.allocate(capacity: 1)
-    hasher.initialize(to: CryptoKit.SHA256())
-    return UnsafeMutableRawPointer(hasher)
-}
-
-@_cdecl("SHA256Write")
-public func SHA256Write(_ ptr: UnsafeMutableRawPointer, _ data: UnsafePointer<UInt8>, _ length: Int) {
-    let hasher = ptr.assumingMemoryBound(to: CryptoKit.SHA256.self)
-    let buffer = UnsafeRawBufferPointer(start: data, count: length)
-
-    hasher.pointee.update(data: buffer)
-
-    // No need to return length as Swift doesn't have partial writes
-}
-
-@_cdecl("SHA256Sum")
-public func SHA256Sum(_ ptr: UnsafeMutableRawPointer, _ outputPointer: UnsafeMutablePointer<UInt8>) {
-    let hasher = ptr.assumingMemoryBound(to: CryptoKit.SHA256.self)
-    let copiedHasher = hasher.pointee
-    let hash = copiedHasher.finalize();
-
-    let hashData = hash.withUnsafeBytes { Data($0) }
-    hashData.copyBytes(to: outputPointer, count: hashData.count)
-}
-
-@_cdecl("SHA256Reset")
-public func SHA256Reset(_ ptr: UnsafeMutableRawPointer) {
-    let hasher = ptr.assumingMemoryBound(to: CryptoKit.SHA256.self)
-    hasher.pointee = CryptoKit.SHA256()
-}
-
-@_cdecl("SHA256Size")
-public func SHA256Size() -> Int {
-    return CryptoKit.SHA256.byteCount
-}
-
-@_cdecl("SHA256BlockSize")
-public func SHA256BlockSize() -> Int {
-    return CryptoKit.SHA256.blockByteCount
-}
-
-@_cdecl("SHA256Copy")
-public func SHA256Copy(_ ptr: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
-    let hasher = ptr.assumingMemoryBound(to: CryptoKit.SHA256.self)
-    let copyOf = hasher.pointee
-    let newHasher = UnsafeMutablePointer<CryptoKit.SHA256>.allocate(capacity: 1)
-    newHasher.initialize(to: copyOf)
-
-    return UnsafeMutableRawPointer(newHasher)
-}
-
-@_cdecl("SHA256Free")
-public func SHA256Free(_ ptr: UnsafeMutableRawPointer) {
-    let hasher = ptr.assumingMemoryBound(to: CryptoKit.SHA256.self)
-    hasher.deallocate()
-}
-
-@_cdecl("NewSHA384")
-public func NewSHA384() -> UnsafeMutableRawPointer {
-    let hasher = UnsafeMutablePointer<CryptoKit.SHA384>.allocate(capacity: 1)
-    hasher.initialize(to: CryptoKit.SHA384())
-    return UnsafeMutableRawPointer(hasher)
-}
-
-@_cdecl("SHA384Write")
-public func SHA384Write(_ ptr: UnsafeMutableRawPointer, _ data: UnsafePointer<UInt8>, _ length: Int) {
-    let hasher = ptr.assumingMemoryBound(to: CryptoKit.SHA384.self)
-    let buffer = UnsafeRawBufferPointer(start: data, count: length)
-
-    hasher.pointee.update(data: buffer)
-
-    // No need to return length as Swift doesn't have partial writes
-}
-
-@_cdecl("SHA384Sum")
-public func SHA384Sum(_ ptr: UnsafeMutableRawPointer, _ outputPointer: UnsafeMutablePointer<UInt8>) {
-    let hasher = ptr.assumingMemoryBound(to: CryptoKit.SHA384.self)
-    let copiedHasher = hasher.pointee
-    let hash = copiedHasher.finalize();
-
-    let hashData = hash.withUnsafeBytes { Data($0) }
-    hashData.copyBytes(to: outputPointer, count: hashData.count)
-}
-
-@_cdecl("SHA384Reset")
-public func SHA384Reset(_ ptr: UnsafeMutableRawPointer) {
-    let hasher = ptr.assumingMemoryBound(to: CryptoKit.SHA384.self)
-    hasher.pointee = CryptoKit.SHA384()
-}
-
-@_cdecl("SHA384Copy")
-public func SHA384Copy(_ ptr: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
-    let hasher = ptr.assumingMemoryBound(to: CryptoKit.SHA384.self)
-    let copyOf = hasher.pointee
-    let newHasher = UnsafeMutablePointer<CryptoKit.SHA384>.allocate(capacity: 1)
-    newHasher.initialize(to: copyOf)
-
-    return UnsafeMutableRawPointer(newHasher)
-}
-
-@_cdecl("SHA384Size")
-public func SHA384Size() -> Int {
-    return CryptoKit.SHA384.byteCount
-}
-
-@_cdecl("SHA384BlockSize")
-public func SHA384BlockSize() -> Int {
-    return CryptoKit.SHA384.blockByteCount
-}
-
-@_cdecl("SHA384Free")
-public func SHA384Free(_ ptr: UnsafeMutableRawPointer) {
-    let hasher = ptr.assumingMemoryBound(to: CryptoKit.SHA384.self)
-    hasher.deallocate()
-}
-
-@_cdecl("NewSHA512")
-public func NewSHA512() -> UnsafeMutableRawPointer {
-    let hasher = UnsafeMutablePointer<CryptoKit.SHA512>.allocate(capacity: 1)
-    hasher.initialize(to: CryptoKit.SHA512())
-    return UnsafeMutableRawPointer(hasher)
-}
-
-@_cdecl("SHA512Write")
-public func SHA512Write(_ ptr: UnsafeMutableRawPointer, _ data: UnsafePointer<UInt8>, _ length: Int) {
-    let hasher = ptr.assumingMemoryBound(to: CryptoKit.SHA512.self)
-    let buffer = UnsafeRawBufferPointer(start: data, count: length)
-
-    hasher.pointee.update(data: buffer)
-
-    // No need to return length as Swift doesn't have partial writes
-}
-
-@_cdecl("SHA512Sum")
-public func SHA512Sum(_ ptr: UnsafeMutableRawPointer, _ outputPointer: UnsafeMutablePointer<UInt8>) {
-    let hasher = ptr.assumingMemoryBound(to: CryptoKit.SHA512.self)
-    let copiedHasher = hasher.pointee
-    let hash = copiedHasher.finalize();
-
-    let hashData = hash.withUnsafeBytes { Data($0) }
-    hashData.copyBytes(to: outputPointer, count: hashData.count)
-}
-
-@_cdecl("SHA512Reset")
-public func SHA512Reset(_ ptr: UnsafeMutableRawPointer) {
-    let hasher = ptr.assumingMemoryBound(to: CryptoKit.SHA512.self)
-    hasher.pointee = CryptoKit.SHA512()
-}
-
-@_cdecl("SHA512Size")
-public func SHA512Size() -> Int {
-    return CryptoKit.SHA512.byteCount
-}
-
-@_cdecl("SHA512BlockSize")
-public func SHA512BlockSize() -> Int {
-    return CryptoKit.SHA512.blockByteCount
-}
-
-@_cdecl("SHA512Copy")
-public func SHA512Copy(_ ptr: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
-    let hasher = ptr.assumingMemoryBound(to: CryptoKit.SHA512.self)
-    let copyOf = hasher.pointee
-    let newHasher = UnsafeMutablePointer<CryptoKit.SHA512>.allocate(capacity: 1)
-    newHasher.initialize(to: copyOf)
-
-    return UnsafeMutableRawPointer(newHasher)
-}
-
-@_cdecl("SHA512Free")
-public func SHA512Free(_ ptr: UnsafeMutableRawPointer) {
-    let hasher = ptr.assumingMemoryBound(to: CryptoKit.SHA512.self)
-    hasher.deallocate()
+@_cdecl("hashFree")
+public func hashFree(_ hashAlgorithm: Int32, _ ptr: UnsafeMutableRawPointer) {
+    switch hashAlgorithm {
+    case 1:
+        let hasher = ptr.assumingMemoryBound(to: Insecure.MD5.self)
+        hasher.deallocate()
+    case 2:
+        let hasher = ptr.assumingMemoryBound(to: Insecure.SHA1.self)
+        hasher.deallocate()
+    case 3:
+        let hasher = ptr.assumingMemoryBound(to: CryptoKit.SHA256.self)
+        hasher.deallocate()
+    case 4:
+        let hasher = ptr.assumingMemoryBound(to: CryptoKit.SHA384.self)
+        hasher.deallocate()
+    case 5:
+        let hasher = ptr.assumingMemoryBound(to: CryptoKit.SHA512.self)
+        hasher.deallocate()
+    default:
+        fatalError("Unsupported hash function")
+    }
 }

--- a/cryptokit/Sources/CryptoKitSrc/hmac.swift
+++ b/cryptokit/Sources/CryptoKitSrc/hmac.swift
@@ -105,23 +105,23 @@ public func finalizeHMAC(
     case 1:
         let hmac = ptr.assumingMemoryBound(to: HMAC<Insecure.MD5>.self)
         let authenticationCode = hmac.pointee.finalize()
-        Data(authenticationCode).copyBytes(to: outputPointer, count: MD5Size())
+        Data(authenticationCode).copyBytes(to: outputPointer, count: Insecure.MD5.byteCount)
     case 2:
         let hmac = ptr.assumingMemoryBound(to: HMAC<Insecure.SHA1>.self)
         let authenticationCode = hmac.pointee.finalize()
-        Data(authenticationCode).copyBytes(to: outputPointer, count: SHA1Size())
+        Data(authenticationCode).copyBytes(to: outputPointer, count: Insecure.SHA1.byteCount)
     case 3:
         let hmac = ptr.assumingMemoryBound(to: HMAC<SHA256>.self)
         let authenticationCode = hmac.pointee.finalize()
-        Data(authenticationCode).copyBytes(to: outputPointer, count: SHA256Size())
+        Data(authenticationCode).copyBytes(to: outputPointer, count: CryptoKit.SHA256.byteCount)
     case 4:
         let hmac = ptr.assumingMemoryBound(to: HMAC<SHA384>.self)
         let authenticationCode = hmac.pointee.finalize()
-        Data(authenticationCode).copyBytes(to: outputPointer, count: SHA384Size())
+        Data(authenticationCode).copyBytes(to: outputPointer, count: CryptoKit.SHA384.byteCount)
     case 5:
         let hmac = ptr.assumingMemoryBound(to: HMAC<SHA512>.self)
         let authenticationCode = hmac.pointee.finalize()
-        Data(authenticationCode).copyBytes(to: outputPointer, count: SHA512Size())
+        Data(authenticationCode).copyBytes(to: outputPointer, count: CryptoKit.SHA512.byteCount)
     default:
         fatalError("Unsupported hash function")
     }

--- a/internal/cryptokit/cgo_go124.go
+++ b/internal/cryptokit/cgo_go124.go
@@ -18,5 +18,23 @@ package cryptokit
 #cgo nocallback SHA384
 #cgo noescape SHA512
 #cgo nocallback SHA512
+
+#cgo noescape hashWrite
+#cgo noescape hashSum
+#cgo nocallback hashNew
+#cgo nocallback hashWrite
+#cgo nocallback hashSum
+#cgo nocallback hashReset
+#cgo nocallback hashSize
+#cgo nocallback hashBlockSize
+#cgo nocallback hashCopy
+#cgo nocallback hashFree
+
+#cgo noescape updateHMAC
+#cgo noescape finalizeHMAC
+#cgo nocallback initMAC
+#cgo nocallback freeHMAC
+#cgo nocallback updateHMAC
+#cgo nocallback finalizeHMAC
 */
 import "C"

--- a/internal/cryptokit/cryptokit.h
+++ b/internal/cryptokit/cryptokit.h
@@ -51,54 +51,13 @@ void SHA256(const uint8_t *inputPointer, size_t inputLength, const uint8_t *outp
 void SHA384(const uint8_t *inputPointer, size_t inputLength, const uint8_t *outputPointer);
 void SHA512(const uint8_t *inputPointer, size_t inputLength, const uint8_t *outputPointer);
 
-// MD5
-void *NewMD5(void);
-int MD5Write(void *ptr, const uint8_t *data, int length);
-void MD5Sum(void *ptr, uint8_t *outputPointer);
-void MD5Reset(void *ptr);
-int MD5Size(void);
-int MD5BlockSize(void);
-void *MD5Copy(void *ptr);
-void MD5Free(void *ptr);
-
-// SHA1
-void *NewSHA1(void);
-void SHA1Write(void *ptr, const uint8_t *data, int length);
-void SHA1Sum(void *ptr, uint8_t *outputPointer);
-void SHA1Reset(void *ptr);
-int SHA1Size(void);
-int SHA1BlockSize(void);
-void *SHA1Copy(void *ptr);
-void SHA1Free(void *ptr);
-
-// SHA256
-void *NewSHA256(void);
-void SHA256Write(void *ptr, const uint8_t *data, int length);
-void SHA256Sum(void *ptr, uint8_t *outputPointer);
-void SHA256Reset(void *ptr);
-int SHA256Size(void);
-int SHA256BlockSize(void);
-void *SHA256Copy(void *ptr);
-void SHA256Free(void *ptr);
-
-// SHA384
-void *NewSHA384(void);
-void SHA384Write(void *ptr, const uint8_t *data, int length);
-void SHA384Sum(void *ptr, uint8_t *outputPointer);
-void SHA384Reset(void *ptr);
-int SHA384Size(void);
-int SHA384BlockSize(void);
-void *SHA384Copy(void *ptr);
-void SHA384Free(void *ptr);
-
-// SHA512
-void *NewSHA512(void);
-void SHA512Write(void *ptr, const uint8_t *data, int length);
-void SHA512Sum(void *ptr, uint8_t *outputPointer);
-void SHA512Reset(void *ptr);
-int SHA512Size(void);
-int SHA512BlockSize(void);
-void *SHA512Copy(void *ptr);
-void SHA512Free(void *ptr);
+void *hashNew(int32_t hashAlgorithm);
+void hashWrite(int32_t hashAlgorithm, void *ptr, const uint8_t *data, int length);
+void hashSum(int32_t hashAlgorithm, void *ptr, uint8_t *outputPointer);
+void hashReset(int32_t hashAlgorithm, void *ptr);
+int hashSize(int32_t hashAlgorithm);
+int hashBlockSize(int32_t hashAlgorithm);
+void *hashCopy(int32_t hashAlgorithm, void *ptr);
+void hashFree(int32_t hashAlgorithm, void *ptr);
 
 #endif /* CRYPTOKIT_H */

--- a/xcrypto/hash_test.go
+++ b/xcrypto/hash_test.go
@@ -443,11 +443,49 @@ func TestHashAllocations(t *testing.T) {
 		sink ^= xcrypto.SHA256(msg)[0]
 		sink ^= xcrypto.SHA512(msg)[0]
 	}))
-	want := 6
+	want := 4
 	if compareCurrentVersion("go1.24") >= 0 {
 		// The go1.24 compiler is able to optimize the allocation away.
 		// See cgo_go124.go for more information.
 		want = 0
+	}
+	if n > want {
+		t.Errorf("allocs = %d, want %d", n, want)
+	}
+}
+
+func TestHashStructAllocations(t *testing.T) {
+	if Asan() {
+		t.Skip("skipping allocations test with sanitizers")
+	}
+	msg := []byte("testing")
+
+	md5Hash := xcrypto.NewMD5()
+	sha1Hash := xcrypto.NewSHA1()
+	sha256Hash := xcrypto.NewSHA256()
+	sha512Hash := xcrypto.NewSHA512()
+
+	n := int(testing.AllocsPerRun(10, func() {
+		md5Hash.Write(msg)
+		sha1Hash.Write(msg)
+		sha256Hash.Write(msg)
+		sha512Hash.Write(msg)
+
+		md5Hash.Sum(nil)
+		sha1Hash.Sum(nil)
+		sha256Hash.Sum(nil)
+		sha512Hash.Sum(nil)
+
+		md5Hash.Reset()
+		sha1Hash.Reset()
+		sha256Hash.Reset()
+		sha512Hash.Reset()
+	}))
+	want := 8
+	if compareCurrentVersion("go1.24") >= 0 {
+		// The go1.24 compiler is able to optimize the allocation away.
+		// See cgo_go124.go for more information.
+		want = 4
 	}
 	if n > want {
 		t.Errorf("allocs = %d, want %d", n, want)

--- a/xcrypto/hash_test.go
+++ b/xcrypto/hash_test.go
@@ -465,16 +465,17 @@ func TestHashStructAllocations(t *testing.T) {
 	sha256Hash := xcrypto.NewSHA256()
 	sha512Hash := xcrypto.NewSHA512()
 
+	sum := make([]byte, sha512Hash.Size())
 	n := int(testing.AllocsPerRun(10, func() {
 		md5Hash.Write(msg)
 		sha1Hash.Write(msg)
 		sha256Hash.Write(msg)
 		sha512Hash.Write(msg)
 
-		md5Hash.Sum(nil)
-		sha1Hash.Sum(nil)
-		sha256Hash.Sum(nil)
-		sha512Hash.Sum(nil)
+		md5Hash.Sum(sum[:0])
+		sha1Hash.Sum(sum[:0])
+		sha256Hash.Sum(sum[:0])
+		sha512Hash.Sum(sum[:0])
 
 		md5Hash.Reset()
 		sha1Hash.Reset()
@@ -485,7 +486,7 @@ func TestHashStructAllocations(t *testing.T) {
 	if compareCurrentVersion("go1.24") >= 0 {
 		// The go1.24 compiler is able to optimize the allocation away.
 		// See cgo_go124.go for more information.
-		want = 4
+		want = 0
 	}
 	if n > want {
 		t.Errorf("allocs = %d, want %d", n, want)

--- a/xcrypto/hmac_test.go
+++ b/xcrypto/hmac_test.go
@@ -75,6 +75,26 @@ func TestHMACUnsupportedHash(t *testing.T) {
 	}
 }
 
+func TestHMACAllocations(t *testing.T) {
+	h := xcrypto.NewHMAC(xcrypto.NewSHA256, nil)
+	msg := []byte("hello world")
+	n := int(testing.AllocsPerRun(10, func() {
+		h.Write(msg)
+		h.Sum(nil)
+		h.Reset()
+	}))
+
+	want := 2
+	if compareCurrentVersion("go1.24") >= 0 {
+		// The go1.24 compiler is able to optimize the allocation away.
+		// See cgo_go124.go for more information.
+		want = 1
+	}
+	if n > want {
+		t.Errorf("allocs = %d, want %d", n, want)
+	}
+}
+
 func BenchmarkHMACSHA256_32(b *testing.B) {
 	b.StopTimer()
 	key := make([]byte, 32)

--- a/xcrypto/hmac_test.go
+++ b/xcrypto/hmac_test.go
@@ -78,9 +78,10 @@ func TestHMACUnsupportedHash(t *testing.T) {
 func TestHMACAllocations(t *testing.T) {
 	h := xcrypto.NewHMAC(xcrypto.NewSHA256, nil)
 	msg := []byte("hello world")
+	sum := make([]byte, xcrypto.NewSHA256().Size())
 	n := int(testing.AllocsPerRun(10, func() {
 		h.Write(msg)
-		h.Sum(nil)
+		h.Sum(sum[:0])
 		h.Reset()
 	}))
 
@@ -88,7 +89,7 @@ func TestHMACAllocations(t *testing.T) {
 	if compareCurrentVersion("go1.24") >= 0 {
 		// The go1.24 compiler is able to optimize the allocation away.
 		// See cgo_go124.go for more information.
-		want = 1
+		want = 0
 	}
 	if n > want {
 		t.Errorf("allocs = %d, want %d", n, want)


### PR DESCRIPTION
HMAC and multiple use hashing functions was allocating on heap, this PR adds cgo directives for not letting it allocate on memory.

Fixes: #45