### PR TITLE
Support building with CGO_ENABLED=0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,10 @@ jobs:
       - name: Build CryptoKit.o
         run: bash gen-swift-bindings.sh
 
+      # Test the code can be built with CGO disabled.
+      - name: Run Build
+        run: CGO_ENABLED=0 go build ./...
+
       - name: Run Go Tests
         run: go test -gcflags=all=-d=checkptr -count 10 -v ./...
 
@@ -45,10 +49,3 @@ jobs:
             echo "CryptoKit.o has been checked in. Please remove this from your PR."
             exit 1
           fi
-  cgolessbuild:
-    runs-on: macos-latest
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-    - name: Run Build
-      run: CGO_ENABLED=0 go build ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,3 +45,10 @@ jobs:
             echo "CryptoKit.o has been checked in. Please remove this from your PR."
             exit 1
           fi
+  cgolessbuild:
+    runs-on: macos-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Run Build
+      run: CGO_ENABLED=0 go build ./...

--- a/internal/cryptokit/doc.go
+++ b/internal/cryptokit/doc.go
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
-
-//go:build darwin
-
-// The cryptokit package provides cryptographic functions using Apple's CryptoKit.
-package cryptokit

--- a/internal/cryptokit/doc.go
+++ b/internal/cryptokit/doc.go
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//go:build darwin
+
+// The cryptokit package provides cryptographic functions using Apple's CryptoKit.
+package cryptokit

--- a/xcrypto/hash.go
+++ b/xcrypto/hash.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//go:build darwin
+//go:build darwin && cgo
 
 package xcrypto
 


### PR DESCRIPTION
This module is sometimes used with `CGO_ENABLED=0`. In that case, compilation should succeed, although the module is unusable. We used to be able to do that, but a recent PR broke it. This is needed for building the Go toolchain (and it is currently blocking https://github.com/microsoft/go/pull/1596).

This PR fixes the issue by readding a `cgo` build constraint to `xcrypto/hash.go`, and a test to ensure we don't regress.