### PR TITLE
Don't use runtime.Pinner to avoid false positive in cgo pointer check

### DIFF
--- a/internal/cryptokit/cryptokit.go
+++ b/internal/cryptokit/cryptokit.go
@@ -16,13 +16,22 @@ func base(b []byte) *C.uchar {
 	return (*C.uchar)(unsafe.Pointer(addr(b)))
 }
 
+// base returns the address of the underlying array in b,
+// being careful not to panic when b has zero length.
+func addr(b []byte) *byte {
+	if len(b) == 0 {
+		return nil
+	}
+	return unsafe.SliceData(b)
+}
+
 var zero byte
 
-// base returns the address of the underlying array in b,
+// addrNeverEmpty returns the address of the underlying array in b,
 // being careful not to panic when b has zero length.
 // If b is empty, it returns a pointer to a zero byte
 // so that it can always be dereferenced.
-func addr(b []byte) *byte {
+func addrNeverEmpty(b []byte) *byte {
 	if len(b) == 0 {
 		return &zero
 	}

--- a/internal/cryptokit/cryptokit.go
+++ b/internal/cryptokit/cryptokit.go
@@ -16,14 +16,15 @@ func base(b []byte) *C.uchar {
 	return (*C.uchar)(unsafe.Pointer(addr(b)))
 }
 
-func sbase(b []byte) *C.char {
-	return (*C.char)(unsafe.Pointer(addr(b)))
-}
+var zero byte
 
-func pbase(b []byte) unsafe.Pointer {
-	return unsafe.Pointer(addr(b))
-}
-
+// base returns the address of the underlying array in b,
+// being careful not to panic when b has zero length.
+// If b is empty, it returns a pointer to a zero byte
+// so that it can always be dereferenced.
 func addr(b []byte) *byte {
+	if len(b) == 0 {
+		return &zero
+	}
 	return unsafe.SliceData(b)
 }

--- a/internal/cryptokit/cryptokit.go
+++ b/internal/cryptokit/cryptokit.go
@@ -13,22 +13,17 @@ import "unsafe"
 // base returns the address of the underlying array in b,
 // being careful not to panic when b has zero length.
 func base(b []byte) *C.uchar {
-	if len(b) == 0 {
-		return nil
-	}
-	return (*C.uchar)(unsafe.Pointer(&b[0]))
+	return (*C.uchar)(unsafe.Pointer(addr(b)))
 }
 
 func sbase(b []byte) *C.char {
-	if len(b) == 0 {
-		return nil
-	}
-	return (*C.char)(unsafe.Pointer(&b[0]))
+	return (*C.char)(unsafe.Pointer(addr(b)))
 }
 
 func pbase(b []byte) unsafe.Pointer {
-	if len(b) == 0 {
-		return nil
-	}
-	return unsafe.Pointer(&b[0])
+	return unsafe.Pointer(addr(b))
+}
+
+func addr(b []byte) *byte {
+	return unsafe.SliceData(b)
 }

--- a/internal/cryptokit/hash.go
+++ b/internal/cryptokit/hash.go
@@ -15,27 +15,27 @@ import (
 )
 
 func MD5(p []byte) (sum [16]byte) {
-	C.MD5((*C.uint8_t)(&*addr(p)), C.size_t(len(p)), base(sum[:]))
+	C.MD5((*C.uint8_t)(&*addrNeverEmpty(p)), C.size_t(len(p)), base(sum[:]))
 	return
 }
 
 func SHA1(p []byte) (sum [20]byte) {
-	C.SHA1((*C.uint8_t)(&*addr(p)), C.size_t(len(p)), base(sum[:]))
+	C.SHA1((*C.uint8_t)(&*addrNeverEmpty(p)), C.size_t(len(p)), base(sum[:]))
 	return
 }
 
 func SHA256(p []byte) (sum [32]byte) {
-	C.SHA256((*C.uint8_t)(&*addr(p)), C.size_t(len(p)), base(sum[:]))
+	C.SHA256((*C.uint8_t)(&*addrNeverEmpty(p)), C.size_t(len(p)), base(sum[:]))
 	return
 }
 
 func SHA384(p []byte) (sum [48]byte) {
-	C.SHA384((*C.uint8_t)(&*addr(p)), C.size_t(len(p)), base(sum[:]))
+	C.SHA384((*C.uint8_t)(&*addrNeverEmpty(p)), C.size_t(len(p)), base(sum[:]))
 	return
 }
 
 func SHA512(p []byte) (sum [64]byte) {
-	C.SHA512((*C.uint8_t)(&*addr(p)), C.size_t(len(p)), base(sum[:]))
+	C.SHA512((*C.uint8_t)(&*addrNeverEmpty(p)), C.size_t(len(p)), base(sum[:]))
 	return
 }
 
@@ -113,6 +113,9 @@ func (h *evpHash) Clone() hash.Hash {
 }
 
 func (h *evpHash) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
 	C.hashWrite(h.hashAlgorithm, h.ptr, (*C.uint8_t)(&*addr(p)), C.int(len(p)))
 
 	runtime.KeepAlive(h)
@@ -121,7 +124,10 @@ func (h *evpHash) Write(p []byte) (int, error) {
 }
 
 func (h *evpHash) WriteString(s string) (int, error) {
-	C.hashWrite(h.hashAlgorithm, h.ptr, base([]byte(s)), C.int(len(s)))
+	if len(s) == 0 {
+		return 0, nil
+	}
+	C.hashWrite(h.hashAlgorithm, h.ptr, (*C.uchar)(unsafe.Pointer(unsafe.StringData(s))), C.int(len(s)))
 
 	runtime.KeepAlive(h)
 

--- a/internal/cryptokit/hash.go
+++ b/internal/cryptokit/hash.go
@@ -15,52 +15,27 @@ import (
 )
 
 func MD5(p []byte) (sum [16]byte) {
-	if len(p) > 0 {
-		var pinner runtime.Pinner
-		pinner.Pin(&p[0])
-		defer pinner.Unpin()
-	}
-	C.MD5(base(p), C.size_t(len(p)), base(sum[:]))
+	C.MD5((*C.uint8_t)(&*addr(p)), C.size_t(len(p)), base(sum[:]))
 	return
 }
 
 func SHA1(p []byte) (sum [20]byte) {
-	if len(p) > 0 {
-		var pinner runtime.Pinner
-		pinner.Pin(&p[0])
-		defer pinner.Unpin()
-	}
-	C.SHA1(base(p), C.size_t(len(p)), base(sum[:]))
+	C.SHA1((*C.uint8_t)(&*addr(p)), C.size_t(len(p)), base(sum[:]))
 	return
 }
 
 func SHA256(p []byte) (sum [32]byte) {
-	if len(p) > 0 {
-		var pinner runtime.Pinner
-		pinner.Pin(&p[0])
-		defer pinner.Unpin()
-	}
-	C.SHA256(base(p), C.size_t(len(p)), base(sum[:]))
+	C.SHA256((*C.uint8_t)(&*addr(p)), C.size_t(len(p)), base(sum[:]))
 	return
 }
 
 func SHA384(p []byte) (sum [48]byte) {
-	if len(p) > 0 {
-		var pinner runtime.Pinner
-		pinner.Pin(&p[0])
-		defer pinner.Unpin()
-	}
-	C.SHA384(base(p), C.size_t(len(p)), base(sum[:]))
+	C.SHA384((*C.uint8_t)(&*addr(p)), C.size_t(len(p)), base(sum[:]))
 	return
 }
 
 func SHA512(p []byte) (sum [64]byte) {
-	if len(p) > 0 {
-		var pinner runtime.Pinner
-		pinner.Pin(&p[0])
-		defer pinner.Unpin()
-	}
-	C.SHA512(base(p), C.size_t(len(p)), base(sum[:]))
+	C.SHA512((*C.uint8_t)(&*addr(p)), C.size_t(len(p)), base(sum[:]))
 	return
 }
 
@@ -99,7 +74,6 @@ var _ hash.Hash = (*evpHash)(nil)
 var _ cloneHash = (*evpHash)(nil)
 
 type evpHash struct {
-	pinner        runtime.Pinner
 	ptr           unsafe.Pointer
 	hashAlgorithm C.int
 	blockSize     int
@@ -139,11 +113,7 @@ func (h *evpHash) Clone() hash.Hash {
 }
 
 func (h *evpHash) Write(p []byte) (int, error) {
-	if len(p) > 0 {
-		h.pinner.Pin(&p[0])
-		defer h.pinner.Unpin()
-	}
-	C.hashWrite(h.hashAlgorithm, h.ptr, base(p), C.int(len(p)))
+	C.hashWrite(h.hashAlgorithm, h.ptr, (*C.uint8_t)(&*addr(p)), C.int(len(p)))
 
 	runtime.KeepAlive(h)
 
@@ -151,12 +121,7 @@ func (h *evpHash) Write(p []byte) (int, error) {
 }
 
 func (h *evpHash) WriteString(s string) (int, error) {
-	p := []byte(s)
-	if len(p) > 0 {
-		h.pinner.Pin(&p[0])
-		defer h.pinner.Unpin()
-	}
-	C.hashWrite(h.hashAlgorithm, h.ptr, base(p), C.int(len(p)))
+	C.hashWrite(h.hashAlgorithm, h.ptr, (*C.uint8_t)(&*unsafe.StringData(s)), C.int(len(s)))
 
 	runtime.KeepAlive(h)
 

--- a/internal/cryptokit/hash.go
+++ b/internal/cryptokit/hash.go
@@ -121,7 +121,7 @@ func (h *evpHash) Write(p []byte) (int, error) {
 }
 
 func (h *evpHash) WriteString(s string) (int, error) {
-	C.hashWrite(h.hashAlgorithm, h.ptr, (*C.uint8_t)(&*unsafe.StringData(s)), C.int(len(s)))
+	C.hashWrite(h.hashAlgorithm, h.ptr, base([]byte(s)), C.int(len(s)))
 
 	runtime.KeepAlive(h)
 

--- a/internal/cryptokit/hash.go
+++ b/internal/cryptokit/hash.go
@@ -116,7 +116,7 @@ func (h *evpHash) Write(p []byte) (int, error) {
 	if len(p) == 0 {
 		return 0, nil
 	}
-	C.hashWrite(h.hashAlgorithm, h.ptr, (*C.uint8_t)(&*addr(p)), C.int(len(p)))
+	C.hashWrite(h.hashAlgorithm, h.ptr, (*C.uint8_t)(&*addrNeverEmpty(p)), C.int(len(p)))
 
 	runtime.KeepAlive(h)
 

--- a/internal/cryptokit/hmac.go
+++ b/internal/cryptokit/hmac.go
@@ -112,7 +112,7 @@ func (h *cryptoKitHMAC) Reset() {
 
 	h.ptr = C.initMAC(
 		C.int(h.kind),
-		(*C.uint8_t)(&*addr(h.key)), C.int(len(h.key)),
+		(*C.uint8_t)(&*addrNeverEmpty(h.key)), C.int(len(h.key)),
 	)
 
 	runtime.KeepAlive(h)

--- a/internal/cryptokit/hmac.go
+++ b/internal/cryptokit/hmac.go
@@ -67,7 +67,7 @@ func NewHMAC(fh func() hash.Hash, key []byte) hash.Hash {
 func (h *cryptoKitHMAC) Write(p []byte) (n int, err error) {
 	C.updateHMAC(C.int(h.kind),
 		h.ptr,
-		(*C.uint8_t)(&*addr(h.key)), C.int(len(p)))
+		(*C.uint8_t)(&*addr(p)), C.int(len(p)))
 
 	runtime.KeepAlive(h)
 

--- a/internal/cryptokit/hmac.go
+++ b/internal/cryptokit/hmac.go
@@ -67,7 +67,7 @@ func NewHMAC(fh func() hash.Hash, key []byte) hash.Hash {
 func (h *cryptoKitHMAC) Write(p []byte) (n int, err error) {
 	C.updateHMAC(C.int(h.kind),
 		h.ptr,
-		(*C.uint8_t)(&*addr(p)), C.int(len(p)))
+		(*C.uint8_t)(&*addrNeverEmpty(p)), C.int(len(p)))
 
 	runtime.KeepAlive(h)
 

--- a/xcrypto/hash_test.go
+++ b/xcrypto/hash_test.go
@@ -72,6 +72,9 @@ func TestHash(t *testing.T) {
 			if n != len(msg) {
 				t.Errorf("got: %d, want: %d", n, len(msg))
 			}
+			// Test that passing and empty slice don't panic.
+			h.Write(nil)
+			h.Write([]byte{})
 			sum := h.Sum(nil)
 			if size := h.Size(); len(sum) != size {
 				t.Errorf("got: %d, want: %d", len(sum), size)

--- a/xcrypto/hmac_test.go
+++ b/xcrypto/hmac_test.go
@@ -24,7 +24,7 @@ func TestHMAC(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			//t.Parallel()
+			t.Parallel()
 			h := xcrypto.NewHMAC(tt.fn, nil)
 			if h == nil {
 				t.Skip("digest not supported")

--- a/xcrypto/hmac_test.go
+++ b/xcrypto/hmac_test.go
@@ -34,6 +34,9 @@ func TestHMAC(t *testing.T) {
 
 			h = xcrypto.NewHMAC(tt.fn, nil)
 			h.Write([]byte("hello world"))
+			// Test that passing and empty slice don't panic.
+			h.Write(nil)
+			h.Write([]byte{})
 
 			sumHelloWorld := h.Sum(nil)
 

--- a/xcrypto/hmac_test.go
+++ b/xcrypto/hmac_test.go
@@ -24,7 +24,7 @@ func TestHMAC(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+			//t.Parallel()
 			h := xcrypto.NewHMAC(tt.fn, nil)
 			if h == nil {
 				t.Skip("digest not supported")

--- a/xcrypto/rc4.go
+++ b/xcrypto/rc4.go
@@ -69,8 +69,8 @@ func (c *RC4Cipher) XORKeyStream(dst, src []byte) {
 	var outLen C.size_t
 	status := C.CCCryptorUpdate(
 		c.ctx,
-		unsafe.Pointer(&*addr(src)), C.size_t(len(src)), // Input
-		unsafe.Pointer(&*addr(dst)), C.size_t(len(dst)), // Output
+		unsafe.Pointer(&*addrNeverEmpty(src)), C.size_t(len(src)), // Input
+		unsafe.Pointer(&*addrNeverEmpty(dst)), C.size_t(len(dst)), // Output
 		&outLen,
 	)
 	if status != C.kCCSuccess {

--- a/xcrypto/rc4.go
+++ b/xcrypto/rc4.go
@@ -11,12 +11,12 @@ import (
 	"errors"
 	"runtime"
 	"slices"
+	"unsafe"
 )
 
 // RC4Cipher is an instance of RC4 using a particular key.
 type RC4Cipher struct {
-	ctx    C.CCCryptorRef
-	pinner runtime.Pinner
+	ctx C.CCCryptorRef
 }
 
 // NewRC4Cipher creates and returns a new RC4 cipher with the given key.
@@ -67,20 +67,10 @@ func (c *RC4Cipher) XORKeyStream(dst, src []byte) {
 	// Ensures `dst` has sufficient space.
 	_ = dst[len(src)-1]
 	var outLen C.size_t
-	// Pin both src and dst to prevent GC from relocating their memory.
-	if len(dst) > 0 || len(src) > 0 {
-		if len(src) > 0 {
-			c.pinner.Pin(&src[0])
-		}
-		if len(dst) > 0 {
-			c.pinner.Pin(&dst[0])
-		}
-		defer c.pinner.Unpin()
-	}
 	status := C.CCCryptorUpdate(
 		c.ctx,
-		pbase(src), C.size_t(len(src)), // Input
-		pbase(dst), C.size_t(len(dst)), // Output
+		unsafe.Pointer(&*addr(src)), C.size_t(len(src)), // Input
+		unsafe.Pointer(&*addr(dst)), C.size_t(len(dst)), // Output
 		&outLen,
 	)
 	if status != C.kCCSuccess {

--- a/xcrypto/xcrypto.go
+++ b/xcrypto/xcrypto.go
@@ -15,22 +15,17 @@ var zero byte
 // base returns the address of the underlying array in b,
 // being careful not to panic when b has zero length.
 func base(b []byte) *C.uchar {
-	if len(b) == 0 {
-		return nil
-	}
-	return (*C.uchar)(unsafe.Pointer(&b[0]))
+	return (*C.uchar)(unsafe.Pointer(addr(b)))
 }
 
 func sbase(b []byte) *C.char {
-	if len(b) == 0 {
-		return nil
-	}
-	return (*C.char)(unsafe.Pointer(&b[0]))
+	return (*C.char)(unsafe.Pointer(addr(b)))
 }
 
 func pbase(b []byte) unsafe.Pointer {
-	if len(b) == 0 {
-		return nil
-	}
-	return unsafe.Pointer(&b[0])
+	return unsafe.Pointer(addr(b))
+}
+
+func addr(b []byte) *byte {
+	return unsafe.SliceData(b)
 }

--- a/xcrypto/xcrypto.go
+++ b/xcrypto/xcrypto.go
@@ -26,6 +26,13 @@ func pbase(b []byte) unsafe.Pointer {
 	return unsafe.Pointer(addr(b))
 }
 
+// base returns the address of the underlying array in b,
+// being careful not to panic when b has zero length.
+// If b is empty, it returns a pointer to a zero byte
+// so that it can always be dereferenced.
 func addr(b []byte) *byte {
+	if len(b) == 0 {
+		return &zero
+	}
 	return unsafe.SliceData(b)
 }

--- a/xcrypto/xcrypto.go
+++ b/xcrypto/xcrypto.go
@@ -36,3 +36,14 @@ func addr(b []byte) *byte {
 	}
 	return unsafe.SliceData(b)
 }
+
+// addrNeverEmpty returns the address of the underlying array in b,
+// being careful not to panic when b has zero length.
+// If b is empty, it returns a pointer to a zero byte
+// so that it can always be dereferenced.
+func addrNeverEmpty(b []byte) *byte {
+	if len(b) == 0 {
+		return &zero
+	}
+	return unsafe.SliceData(b)
+}


### PR DESCRIPTION
`runtime.Pinner` confuses the Go compiler, making it skip some optimizations. See for example https://github.com/microsoft/go/issues/1629.

Additionally, the cgo check pointer implementation doesn't handle all pinned cases. See for example https://github.com/golang/go/blob/786e62bcd3f03d73ddf0c999780ffe6f1a0319ea/src/runtime/cgocall.go#L741, where the check fails without honoring the pinning status. I've seen this code path reached while running the Go standard library test suite when using the Darwin backend.