### PR TITLE
Add hash.Clone interface for HMAC and Hash

### DIFF
--- a/cryptokit/Sources/CryptoKitSrc/hmac.swift
+++ b/cryptokit/Sources/CryptoKitSrc/hmac.swift
@@ -95,6 +95,49 @@ public func updateHMAC(
     }
 }
 
+@_cdecl("copyHMAC")
+public func copyHMAC(_ hashAlgorithm: Int32, _ ptr: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+    switch hashAlgorithm {
+    case 1:
+        let hmac = ptr.assumingMemoryBound(to: HMAC<Insecure.MD5>.self)
+        let copyOf = hmac.pointee
+        let newHasher = UnsafeMutablePointer<HMAC<Insecure.MD5>>.allocate(capacity: 1)
+        newHasher.initialize(to: copyOf)
+
+        return UnsafeMutableRawPointer(newHasher)
+    case 2:
+        let hmac = ptr.assumingMemoryBound(to: HMAC<Insecure.SHA1>.self)
+        let copyOf = hmac.pointee
+        let newHasher = UnsafeMutablePointer<HMAC<Insecure.SHA1>>.allocate(capacity: 1)
+        newHasher.initialize(to: copyOf)
+
+        return UnsafeMutableRawPointer(newHasher)
+    case 3:
+        let hmac = ptr.assumingMemoryBound(to: HMAC<SHA256>.self)
+        let copyOf = hmac.pointee
+        let newHasher = UnsafeMutablePointer<HMAC<SHA256>>.allocate(capacity: 1)
+        newHasher.initialize(to: copyOf)
+
+        return UnsafeMutableRawPointer(newHasher)
+    case 4:
+        let hmac = ptr.assumingMemoryBound(to: HMAC<SHA384>.self)
+        let copyOf = hmac.pointee
+        let newHasher = UnsafeMutablePointer<HMAC<SHA384>>.allocate(capacity: 1)
+        newHasher.initialize(to: copyOf)
+
+        return UnsafeMutableRawPointer(newHasher)
+    case 5:
+        let hmac = ptr.assumingMemoryBound(to: HMAC<SHA512>.self)
+        let copyOf = hmac.pointee
+        let newHasher = UnsafeMutablePointer<HMAC<SHA512>>.allocate(capacity: 1)
+        newHasher.initialize(to: copyOf)
+
+        return UnsafeMutableRawPointer(newHasher)
+    default:
+        fatalError("Unsupported hash function")
+    }
+}
+
 @_cdecl("finalizeHMAC")
 public func finalizeHMAC(
     _ hashFunction: Int32,

--- a/cryptokit/Sources/CryptoKitSrc/hmac.swift
+++ b/cryptokit/Sources/CryptoKitSrc/hmac.swift
@@ -4,7 +4,7 @@
 import CryptoKit
 import Foundation
 
-@_cdecl("initMAC")
+@_cdecl("initHMAC")
 public func initHMAC(
     _ hashFunction: Int32,
     _ keyPointer: UnsafePointer<UInt8>,
@@ -165,6 +165,53 @@ public func finalizeHMAC(
         let hmac = ptr.assumingMemoryBound(to: HMAC<SHA512>.self)
         let authenticationCode = hmac.pointee.finalize()
         Data(authenticationCode).copyBytes(to: outputPointer, count: CryptoKit.SHA512.byteCount)
+    default:
+        fatalError("Unsupported hash function")
+    }
+}
+
+@_cdecl("hmacSize")
+public func hmacSize(_ hashFunction: Int32) -> Int {
+    switch hashFunction {
+    case 1:
+        return Insecure.MD5.byteCount
+    case 2:
+        return Insecure.SHA1.byteCount
+    case 3:
+        return CryptoKit.SHA256.byteCount
+    case 4:
+        return CryptoKit.SHA384.byteCount
+    case 5:
+        return CryptoKit.SHA512.byteCount
+    default:
+        fatalError("Unsupported hash function")
+    }
+}
+
+@_cdecl("resetHMAC")
+public func resetHMAC(
+    _ hashFunction: Int32,
+    _ ptr: UnsafeMutableRawPointer,
+    _ keyPointer: UnsafePointer<UInt8>,
+    _ keyLength: Int
+) {
+    let key: SymmetricKey = SymmetricKey(data: Data(bytes: keyPointer, count: keyLength))
+    switch hashFunction {
+    case 1:
+        let hmac = ptr.assumingMemoryBound(to: HMAC<Insecure.MD5>.self)
+        hmac.pointee = CryptoKit.HMAC<Insecure.MD5>(key: key)
+    case 2:
+        let hmac = ptr.assumingMemoryBound(to: HMAC<Insecure.SHA1>.self)
+        hmac.pointee = CryptoKit.HMAC<Insecure.SHA1>(key: key)
+    case 3:
+        let hmac = ptr.assumingMemoryBound(to: HMAC<SHA256>.self)
+        hmac.pointee = CryptoKit.HMAC<SHA256>(key: key)
+    case 4:
+        let hmac = ptr.assumingMemoryBound(to: HMAC<SHA384>.self)
+        hmac.pointee = CryptoKit.HMAC<SHA384>(key: key)
+    case 5:
+        let hmac = ptr.assumingMemoryBound(to: HMAC<SHA512>.self)
+        hmac.pointee = CryptoKit.HMAC<SHA512>(key: key)
     default:
         fatalError("Unsupported hash function")
     }

--- a/cryptokit/Tests/CryptoKitTests/TestUtils.swift
+++ b/cryptokit/Tests/CryptoKitTests/TestUtils.swift
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import Foundation
+
+// MARK: - Data <-> Hex String Helpers (Shared Test Utilities)
+extension Data {
+    /// Returns a hexadecimal string representation of the data.
+    func hexEncodedString() -> String {
+        map { String(format: "%02hhx", $0) }.joined()
+    }
+
+    /// Initializes Data from a hexadecimal string representation.
+    init?(hexString: String) {
+        let len = hexString.count / 2
+        var data = Data(capacity: len)
+        var index = hexString.startIndex
+        for _ in 0..<len {
+            let nextIndex = hexString.index(index, offsetBy: 2)
+            if let b = UInt8(hexString[index..<nextIndex], radix: 16) {
+                data.append(b)
+            } else {
+                // Handle potential invalid characters or odd length
+                return nil
+            }
+            index = nextIndex
+        }
+        // Ensure the entire string was consumed (no trailing characters)
+        guard index == hexString.endIndex else { return nil }
+        self.init(data)
+    }
+
+    // Keep existing computed property if needed elsewhere, but prefer function for clarity
+    var hexString: String {
+        return self.hexEncodedString()
+    }
+}

--- a/cryptokit/Tests/CryptoKitTests/hash.swift
+++ b/cryptokit/Tests/CryptoKitTests/hash.swift
@@ -7,39 +7,6 @@ import XCTest
 
 @testable import CryptoKitSrc
 
-// MARK: - Data <-> Hex String Helpers (Combined & Enhanced)
-extension Data {
-    /// Returns a hexadecimal string representation of the data.
-    func hexEncodedString() -> String {
-        map { String(format: "%02hhx", $0) }.joined()
-    }
-
-    /// Initializes Data from a hexadecimal string representation.
-    init?(hexString: String) {
-        let len = hexString.count / 2
-        var data = Data(capacity: len)
-        var index = hexString.startIndex
-        for _ in 0..<len {
-            let nextIndex = hexString.index(index, offsetBy: 2)
-            if let b = UInt8(hexString[index..<nextIndex], radix: 16) {
-                data.append(b)
-            } else {
-                // Handle potential invalid characters or odd length
-                return nil
-            }
-            index = nextIndex
-        }
-        // Ensure the entire string was consumed (no trailing characters)
-        guard index == hexString.endIndex else { return nil }
-        self.init(data)
-    }
-
-    // Keep existing computed property if needed elsewhere, but prefer function for clarity
-    var hexString: String {
-        return self.hexEncodedString()
-    }
-}
-
 // MARK: - Hash Function Configuration Structure (for C-Style Wrappers)
 // Placed outside the class for better organization, or could be nested inside.
 struct HashingFunctions {
@@ -83,7 +50,7 @@ final class CryptoKitTests: XCTestCase {
 
         // Known MD5 hash for the test string (as hex)
         let expectedHex = "9e107d9d372bb6826bd81d3542a419d6"
-        XCTAssertEqual(Data(output).hexString, expectedHex)
+        XCTAssertEqual(Data(output).hexEncodedString(), expectedHex)
 
         // Test empty string
         let emptyInput = Array(emptyString.utf8)
@@ -96,7 +63,7 @@ final class CryptoKitTests: XCTestCase {
 
         // Known MD5 hash for empty string
         let emptyExpectedHex = "d41d8cd98f00b204e9800998ecf8427e"
-        XCTAssertEqual(Data(emptyOutput).hexString, emptyExpectedHex)
+        XCTAssertEqual(Data(emptyOutput).hexEncodedString(), emptyExpectedHex)
     }
 
     // Test SHA1 hash function (Simple API)
@@ -112,7 +79,7 @@ final class CryptoKitTests: XCTestCase {
 
         // Known SHA1 hash for the test string
         let expectedHex = "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12"
-        XCTAssertEqual(Data(output).hexString, expectedHex)
+        XCTAssertEqual(Data(output).hexEncodedString(), expectedHex)
 
         // Test empty string
         let emptyInput = Array(emptyString.utf8)
@@ -125,7 +92,7 @@ final class CryptoKitTests: XCTestCase {
 
         // Known SHA1 hash for empty string
         let emptyExpectedHex = "da39a3ee5e6b4b0d3255bfef95601890afd80709"
-        XCTAssertEqual(Data(emptyOutput).hexString, emptyExpectedHex)
+        XCTAssertEqual(Data(emptyOutput).hexEncodedString(), emptyExpectedHex)
     }
 
     // Test SHA256 hash function (Simple API)
@@ -141,7 +108,7 @@ final class CryptoKitTests: XCTestCase {
 
         // Known SHA256 hash for the test string
         let expectedHex = "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592"
-        XCTAssertEqual(Data(output).hexString, expectedHex)
+        XCTAssertEqual(Data(output).hexEncodedString(), expectedHex)
 
         // Test empty string
         let emptyInput = Array(emptyString.utf8)
@@ -154,7 +121,7 @@ final class CryptoKitTests: XCTestCase {
 
         // Known SHA256 hash for empty string
         let emptyExpectedHex = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-        XCTAssertEqual(Data(emptyOutput).hexString, emptyExpectedHex)
+        XCTAssertEqual(Data(emptyOutput).hexEncodedString(), emptyExpectedHex)
     }
 
     // Test SHA384 hash function (Simple API)
@@ -171,7 +138,7 @@ final class CryptoKitTests: XCTestCase {
         // Known SHA384 hash for the test string
         let expectedHex =
             "ca737f1014a48f4c0b6dd43cb177b0afd9e5169367544c494011e3317dbf9a509cb1e5dc1e85a941bbee3d7f2afbc9b1"
-        XCTAssertEqual(Data(output).hexString, expectedHex)
+        XCTAssertEqual(Data(output).hexEncodedString(), expectedHex)
 
         // Test empty string
         let emptyInput = Array(emptyString.utf8)
@@ -186,7 +153,7 @@ final class CryptoKitTests: XCTestCase {
         // Correction: Original code had a typo in the empty hash for SHA384 (last digit was b instead of 4)
         let emptyExpectedHex =
             "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b"
-        XCTAssertEqual(Data(emptyOutput).hexString, emptyExpectedHex)
+        XCTAssertEqual(Data(emptyOutput).hexEncodedString(), emptyExpectedHex)
     }
 
     // Test SHA512 hash function (Simple API)
@@ -203,7 +170,7 @@ final class CryptoKitTests: XCTestCase {
         // Known SHA512 hash for the test string
         let expectedHex =
             "07e547d9586f6a73f73fbac0435ed76951218fb7d0c8d788a309d785436bbb642e93a252a954f23912547d1e8a3b5ed6e1bfd7097821233fa0538f3db854fee6"
-        XCTAssertEqual(Data(output).hexString, expectedHex)
+        XCTAssertEqual(Data(output).hexEncodedString(), expectedHex)
 
         // Test empty string
         let emptyInput = Array(emptyString.utf8)
@@ -217,7 +184,7 @@ final class CryptoKitTests: XCTestCase {
         // Known SHA512 hash for empty string
         let emptyExpectedHex =
             "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
-        XCTAssertEqual(Data(emptyOutput).hexString, emptyExpectedHex)
+        XCTAssertEqual(Data(emptyOutput).hexEncodedString(), emptyExpectedHex)
     }
 
     // MARK: - C-Style Function Tests (Advanced API)

--- a/cryptokit/Tests/CryptoKitTests/hmac.swift
+++ b/cryptokit/Tests/CryptoKitTests/hmac.swift
@@ -1,37 +1,65 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import CryptoKit
+import Foundation
 import XCTest
 
 @testable import CryptoKitSrc
 
+// MARK: - HMAC Function Configuration Structure
+struct HMACFunctions {
+    let name: String
+    let hashFunction: Int32
+    let initHMAC: (UnsafePointer<UInt8>, Int) -> UnsafeMutableRawPointer
+    let update: (UnsafeMutableRawPointer, UnsafePointer<UInt8>, Int) -> Void
+    let finalize: (UnsafeMutableRawPointer, UnsafeMutablePointer<UInt8>) -> Void
+    let reset: (UnsafeMutableRawPointer, UnsafePointer<UInt8>, Int) -> Void
+    let copy: (UnsafeMutableRawPointer) -> UnsafeMutableRawPointer
+    let free: (UnsafeMutableRawPointer) -> Void
+    let size: () -> Int
+
+    // Expected values for verification
+    let expectedSize: Int
+    let knownEmptyKeyHMACHex: String  // HMAC with empty key and empty message
+    let knownTestKeyMessageHMACHex: String  // HMAC with "key" and "hello world"
+}
+
 class HMACTests: XCTestCase {
-    func testHMAC_MD5() {
-        runHMACTest(hashFunction: 1, key: "secret", message: "Hello, world!")
+
+    // MARK: - Properties for Tests
+    let testKey = "key"
+    let testMessage = "hello world"
+    let emptyKey = ""
+    let emptyMessage = ""
+    // MARK: - Simple HMAC Tests (Basic API)
+    func testHMAC_MD5_Simple() {
+        runSimpleHMACTest(hashFunction: 1, key: "secret", message: "Hello, world!")
     }
 
-    func testHMAC_SHA1() {
-        runHMACTest(hashFunction: 2, key: "secret", message: "Hello, world!")
+    func testHMAC_SHA1_Simple() {
+        runSimpleHMACTest(hashFunction: 2, key: "secret", message: "Hello, world!")
     }
 
-    func testHMAC_SHA256() {
-        runHMACTest(hashFunction: 3, key: "secret", message: "Hello, world!")
+    func testHMAC_SHA256_Simple() {
+        runSimpleHMACTest(hashFunction: 3, key: "secret", message: "Hello, world!")
     }
 
-    func testHMAC_SHA384() {
-        runHMACTest(hashFunction: 4, key: "secret", message: "Hello, world!")
+    func testHMAC_SHA384_Simple() {
+        runSimpleHMACTest(hashFunction: 4, key: "secret", message: "Hello, world!")
     }
 
-    func testHMAC_SHA512() {
-        runHMACTest(hashFunction: 5, key: "secret", message: "Hello, world!")
+    func testHMAC_SHA512_Simple() {
+        runSimpleHMACTest(hashFunction: 5, key: "secret", message: "Hello, world!")
     }
 
-    private func runHMACTest(hashFunction: Int32, key: String, message: String) {
+    private func runSimpleHMACTest(hashFunction: Int32, key: String, message: String) {
         let keyData = key.data(using: .utf8)!
         let messageData = message.data(using: .utf8)!
 
         let keyPointer = keyData.withUnsafeBytes { $0.baseAddress!.assumingMemoryBound(to: UInt8.self) }
         let hmacPointer = initHMAC(hashFunction, keyPointer, keyData.count)
+        defer { freeHMAC(hashFunction, hmacPointer) }
 
         let messagePointer = messageData.withUnsafeBytes { $0.baseAddress!.assumingMemoryBound(to: UInt8.self) }
         updateHMAC(hashFunction, hmacPointer, messagePointer, messageData.count)
@@ -40,11 +68,188 @@ class HMACTests: XCTestCase {
         var output = [UInt8](repeating: 0, count: outputSize)
         finalizeHMAC(hashFunction, hmacPointer, &output)
 
-        freeHMAC(hashFunction, hmacPointer)
-
         XCTAssertFalse(output.allSatisfy { $0 == 0 }, "HMAC output should not be all zeros")
     }
 
+    // MARK: - Comprehensive HMAC Function Tests (Advanced API)
+    func testHMACFunctions() {
+        let testKeyData = Data(testKey.utf8)
+        let testMessageData = Data(testMessage.utf8)
+        let emptyKeyData = Data(emptyKey.utf8)
+        let emptyMessageData = Data(emptyMessage.utf8)
+
+        let functionsList: [HMACFunctions] = [
+            HMACFunctions(
+                name: "HMAC-MD5",
+                hashFunction: 1,
+                initHMAC: { keyPtr, keyLen in initHMAC(1, keyPtr, keyLen) },
+                update: { ptr, data, length in updateHMAC(1, ptr, data, length) },
+                finalize: { ptr, out in finalizeHMAC(1, ptr, out) },
+                reset: { ptr, keyPtr, keyLen in resetHMAC(1, ptr, keyPtr, keyLen) },
+                copy: { ptr in copyHMAC(1, ptr) },
+                free: { ptr in freeHMAC(1, ptr) },
+                size: { hmacSize(1) },
+                expectedSize: Insecure.MD5.byteCount,
+                knownEmptyKeyHMACHex: "74e6f7298a9c2d168935f58c001bad88",  // HMAC-MD5("", "")
+                knownTestKeyMessageHMACHex: "ae92cf51adf91130130aefc2b39a7595"  // HMAC-MD5("key", "hello world") - Swift actual output
+            ),
+            HMACFunctions(
+                name: "HMAC-SHA1",
+                hashFunction: 2,
+                initHMAC: { keyPtr, keyLen in initHMAC(2, keyPtr, keyLen) },
+                update: { ptr, data, length in updateHMAC(2, ptr, data, length) },
+                finalize: { ptr, out in finalizeHMAC(2, ptr, out) },
+                reset: { ptr, keyPtr, keyLen in resetHMAC(2, ptr, keyPtr, keyLen) },
+                copy: { ptr in copyHMAC(2, ptr) },
+                free: { ptr in freeHMAC(2, ptr) },
+                size: { hmacSize(2) },
+                expectedSize: Insecure.SHA1.byteCount,
+                knownEmptyKeyHMACHex: "fbdb1d1b18aa6c08324b7d64b71fb76370690e1d",  // HMAC-SHA1("", "")
+                knownTestKeyMessageHMACHex: "34dd234b92683593560528f6193ea68c8005f615"  // HMAC-SHA1("key", "hello world") - Swift actual output
+            ),
+            HMACFunctions(
+                name: "HMAC-SHA256",
+                hashFunction: 3,
+                initHMAC: { keyPtr, keyLen in initHMAC(3, keyPtr, keyLen) },
+                update: { ptr, data, length in updateHMAC(3, ptr, data, length) },
+                finalize: { ptr, out in finalizeHMAC(3, ptr, out) },
+                reset: { ptr, keyPtr, keyLen in resetHMAC(3, ptr, keyPtr, keyLen) },
+                copy: { ptr in copyHMAC(3, ptr) },
+                free: { ptr in freeHMAC(3, ptr) },
+                size: { hmacSize(3) },
+                expectedSize: CryptoKit.SHA256.byteCount,
+                knownEmptyKeyHMACHex: "b613679a0814d9ec772f95d778c35fc5ff1697c493715653c6c712144292c5ad",  // HMAC-SHA256("", "")
+                knownTestKeyMessageHMACHex: "0ba06f1f9a6300461e43454535dc3c4223e47b1d357073d7536eae90ec095be1"  // HMAC-SHA256("key", "hello world") - Swift actual output
+            ),
+            HMACFunctions(
+                name: "HMAC-SHA384",
+                hashFunction: 4,
+                initHMAC: { keyPtr, keyLen in initHMAC(4, keyPtr, keyLen) },
+                update: { ptr, data, length in updateHMAC(4, ptr, data, length) },
+                finalize: { ptr, out in finalizeHMAC(4, ptr, out) },
+                reset: { ptr, keyPtr, keyLen in resetHMAC(4, ptr, keyPtr, keyLen) },
+                copy: { ptr in copyHMAC(4, ptr) },
+                free: { ptr in freeHMAC(4, ptr) },
+                size: { hmacSize(4) },
+                expectedSize: CryptoKit.SHA384.byteCount,
+                knownEmptyKeyHMACHex:
+                    "6c1f2ee938fad2e24bd91298474382ca218c75db3d83e114b3d4367776d14d3551289e75e8209cd4b792302840234adc",  // HMAC-SHA384("", "")
+                knownTestKeyMessageHMACHex:
+                    "b7e365fa38bb22d6553614a63095564a0411866e65aac7b835d02d0b24245f4dc48696c9d970ac20f24105be7dc60133"  // HMAC-SHA384("key", "hello world")
+            ),
+            HMACFunctions(
+                name: "HMAC-SHA512",
+                hashFunction: 5,
+                initHMAC: { keyPtr, keyLen in initHMAC(5, keyPtr, keyLen) },
+                update: { ptr, data, length in updateHMAC(5, ptr, data, length) },
+                finalize: { ptr, out in finalizeHMAC(5, ptr, out) },
+                reset: { ptr, keyPtr, keyLen in resetHMAC(5, ptr, keyPtr, keyLen) },
+                copy: { ptr in copyHMAC(5, ptr) },
+                free: { ptr in freeHMAC(5, ptr) },
+                size: { hmacSize(5) },
+                expectedSize: CryptoKit.SHA512.byteCount,
+                knownEmptyKeyHMACHex:
+                    "b936cee86c9f87aa5d3c6f2e84cb5a4239a5fe50480a6ec66b70ab5b1f4ac6730c6c515421b327ec1d69402e53dfb49ad7381eb067b338fd7b0cb22247225d47",  // HMAC-SHA512("", "")
+                knownTestKeyMessageHMACHex:
+                    "ea0625a5ff1cd1653a327f8a4ae2f478fc51405c73ddac3a8a05a7a810310a6a14d7c8b4d284013493a6016ecadc772cfd98ed6cbe745949c5e6119fafb63b54"  // HMAC-SHA512("key", "hello world")
+            ),
+        ]
+
+        for functions in functionsList {
+            // Test size function
+            XCTAssertEqual(functions.size(), functions.expectedSize, "\(functions.name) size mismatch")
+
+            // Test empty key and empty message HMAC
+            emptyKeyData.withUnsafeBytes { emptyKeyBytes in
+                emptyMessageData.withUnsafeBytes { emptyMessageBytes in
+                    let emptyKeyPtr = emptyKeyBytes.baseAddress!.assumingMemoryBound(to: UInt8.self)
+                    let emptyPtr = functions.initHMAC(emptyKeyPtr, emptyKeyData.count)
+                    defer { functions.free(emptyPtr) }
+
+                    let emptyMessagePtr = emptyMessageBytes.baseAddress!.assumingMemoryBound(to: UInt8.self)
+                    functions.update(emptyPtr, emptyMessagePtr, emptyMessageData.count)
+
+                    let emptyOutput = UnsafeMutablePointer<UInt8>.allocate(capacity: functions.size())
+                    defer { emptyOutput.deallocate() }
+
+                    functions.finalize(emptyPtr, emptyOutput)
+                    XCTAssertEqual(
+                        Data(buffer: UnsafeBufferPointer(start: emptyOutput, count: functions.size()))
+                            .hexEncodedString(),
+                        functions.knownEmptyKeyHMACHex,
+                        "\(functions.name) empty key/message HMAC mismatch"
+                    )
+                }
+            }
+
+            // Test with test key and message
+            testKeyData.withUnsafeBytes { testKeyBytes in
+                testMessageData.withUnsafeBytes { testMessageBytes in
+                    let testKeyPtr = testKeyBytes.baseAddress!.assumingMemoryBound(to: UInt8.self)
+                    let testPtr = functions.initHMAC(testKeyPtr, testKeyData.count)
+                    defer { functions.free(testPtr) }
+
+                    let testMessagePtr = testMessageBytes.baseAddress!.assumingMemoryBound(to: UInt8.self)
+                    functions.update(testPtr, testMessagePtr, testMessageData.count)
+
+                    // Test copy functionality (must be done BEFORE finalize)
+                    let copyPtr = functions.copy(testPtr)
+                    defer { functions.free(copyPtr) }
+
+                    let testOutput = UnsafeMutablePointer<UInt8>.allocate(capacity: functions.size())
+                    defer { testOutput.deallocate() }
+
+                    functions.finalize(testPtr, testOutput)
+                    XCTAssertEqual(
+                        Data(buffer: UnsafeBufferPointer(start: testOutput, count: functions.size()))
+                            .hexEncodedString(),
+                        functions.knownTestKeyMessageHMACHex,
+                        "\(functions.name) test key/message HMAC mismatch"
+                    )
+
+                    let copyOutput = UnsafeMutablePointer<UInt8>.allocate(capacity: functions.size())
+                    defer { copyOutput.deallocate() }
+
+                    functions.finalize(copyPtr, copyOutput)
+                    XCTAssertEqual(
+                        Data(buffer: UnsafeBufferPointer(start: copyOutput, count: functions.size()))
+                            .hexEncodedString(),
+                        functions.knownTestKeyMessageHMACHex,
+                        "\(functions.name) copied HMAC mismatch"
+                    )
+
+                    // Test reset functionality (use a fresh context)
+                    emptyKeyData.withUnsafeBytes { emptyKeyBytes in
+                        emptyMessageData.withUnsafeBytes { emptyMessageBytes in
+                            let resetPtr = functions.initHMAC(testKeyPtr, testKeyData.count)
+                            defer { functions.free(resetPtr) }
+
+                            functions.update(resetPtr, testMessagePtr, testMessageData.count)
+
+                            let emptyKeyPtr = emptyKeyBytes.baseAddress!.assumingMemoryBound(to: UInt8.self)
+                            functions.reset(resetPtr, emptyKeyPtr, emptyKeyData.count)
+
+                            let emptyMessagePtr = emptyMessageBytes.baseAddress!.assumingMemoryBound(to: UInt8.self)
+                            functions.update(resetPtr, emptyMessagePtr, emptyMessageData.count)
+
+                            let resetOutput = UnsafeMutablePointer<UInt8>.allocate(capacity: functions.size())
+                            defer { resetOutput.deallocate() }
+
+                            functions.finalize(resetPtr, resetOutput)
+                            XCTAssertEqual(
+                                Data(buffer: UnsafeBufferPointer(start: resetOutput, count: functions.size()))
+                                    .hexEncodedString(),
+                                functions.knownEmptyKeyHMACHex,
+                                "\(functions.name) reset HMAC mismatch"
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Helper Functions
     private func getHMACOutputSize(_ hashFunction: Int32) -> Int {
         switch hashFunction {
         case 1: return 16  // MD5

--- a/internal/cryptokit/cgo_go124.go
+++ b/internal/cryptokit/cgo_go124.go
@@ -32,7 +32,7 @@ package cryptokit
 
 #cgo noescape updateHMAC
 #cgo noescape finalizeHMAC
-#cgo nocallback initMAC
+#cgo nocallback initHMAC
 #cgo nocallback freeHMAC
 #cgo nocallback updateHMAC
 #cgo nocallback finalizeHMAC

--- a/internal/cryptokit/cryptokit.h
+++ b/internal/cryptokit/cryptokit.h
@@ -44,6 +44,7 @@ void *initMAC(int32_t hashFunction, const uint8_t *key, int keyLength);
 void freeHMAC(int32_t hashFunction, void *ptr);
 void updateHMAC(int32_t hashFunction, void *ptr, const uint8_t *data, int length);
 void finalizeHMAC(int32_t hashFunction, void *ptr, uint8_t *outputPointer);
+void *copyHMAC(int32_t hashAlgorithm, void *ptr);
 
 void MD5(const uint8_t *inputPointer, size_t inputLength, const uint8_t *outputPointer);
 void SHA1(const uint8_t *inputPointer, size_t inputLength, const uint8_t *outputPointer);

--- a/internal/cryptokit/cryptokit.h
+++ b/internal/cryptokit/cryptokit.h
@@ -4,56 +4,59 @@
 #ifndef CRYPTOKIT_H
 #define CRYPTOKIT_H
 
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
 
 // AES GCM encryption and decryption
-int encryptAESGCM(const uint8_t *key, size_t keyLength,
-                  const uint8_t *data, size_t dataLength,
-                  const uint8_t *nonce, size_t nonceLength,
-                  const uint8_t *aad, size_t aadLength,
-                  uint8_t *cipherText, size_t cipherTextLength,
-                  uint8_t *tag);
-int decryptAESGCM(const uint8_t *key, size_t keyLength,
-                  const uint8_t *data, size_t dataLength,
-                  const uint8_t *nonce, size_t nonceLength,
-                  const uint8_t *aad, size_t aadLength,
-                  const uint8_t *tag, size_t tagLength,
-                  uint8_t *out, size_t *outLength);
+int encryptAESGCM(const uint8_t *key, size_t keyLength, const uint8_t *data,
+                  size_t dataLength, const uint8_t *nonce, size_t nonceLength,
+                  const uint8_t *aad, size_t aadLength, uint8_t *cipherText,
+                  size_t cipherTextLength, uint8_t *tag);
+int decryptAESGCM(const uint8_t *key, size_t keyLength, const uint8_t *data,
+                  size_t dataLength, const uint8_t *nonce, size_t nonceLength,
+                  const uint8_t *aad, size_t aadLength, const uint8_t *tag,
+                  size_t tagLength, uint8_t *out, size_t *outLength);
 
 // Generates an Ed25519 keypair.
-// The private key is 64 bytes (first 32 bytes are the seed, next 32 bytes are the public key).
-// The public key is 32 bytes.
+// The private key is 64 bytes (first 32 bytes are the seed, next 32 bytes are
+// the public key). The public key is 32 bytes.
 void generateKeyEd25519(uint8_t *key);
 int newPrivateKeyEd25519FromSeed(uint8_t *key, const uint8_t *seed);
 int newPublicKeyEd25519(uint8_t *key, const uint8_t *pub);
-int signEd25519(const uint8_t *privateKey, const uint8_t *message, size_t messageLength, uint8_t *sigBuffer);
-int verifyEd25519(const uint8_t *publicKey, const uint8_t *message, size_t messageLength, const uint8_t *sig);
+int signEd25519(const uint8_t *privateKey, const uint8_t *message,
+                size_t messageLength, uint8_t *sigBuffer);
+int verifyEd25519(const uint8_t *publicKey, const uint8_t *message,
+                  size_t messageLength, const uint8_t *sig);
 
 // HKDF key derivation
-int extractHKDF(int32_t hashFunction,
-                const uint8_t *secret, size_t secretLength,
-                const uint8_t *salt, size_t saltLength,
+int extractHKDF(int32_t hashFunction, const uint8_t *secret,
+                size_t secretLength, const uint8_t *salt, size_t saltLength,
                 uint8_t *prk, size_t prkLength);
-int expandHKDF(int32_t hashFunction,
-               const uint8_t *prk, size_t prkLength,
-               const uint8_t *info, size_t infoLength,
-               uint8_t *okm, size_t okmLength);
+int expandHKDF(int32_t hashFunction, const uint8_t *prk, size_t prkLength,
+               const uint8_t *info, size_t infoLength, uint8_t *okm,
+               size_t okmLength);
 
-void *initMAC(int32_t hashFunction, const uint8_t *key, int keyLength);
+void *initHMAC(int32_t hashFunction, const uint8_t *key, int keyLength);
 void freeHMAC(int32_t hashFunction, void *ptr);
-void updateHMAC(int32_t hashFunction, void *ptr, const uint8_t *data, int length);
+void updateHMAC(int32_t hashFunction, void *ptr, const uint8_t *data,
+                int length);
 void finalizeHMAC(int32_t hashFunction, void *ptr, uint8_t *outputPointer);
 void *copyHMAC(int32_t hashAlgorithm, void *ptr);
 
-void MD5(const uint8_t *inputPointer, size_t inputLength, const uint8_t *outputPointer);
-void SHA1(const uint8_t *inputPointer, size_t inputLength, const uint8_t *outputPointer);
-void SHA256(const uint8_t *inputPointer, size_t inputLength, const uint8_t *outputPointer);
-void SHA384(const uint8_t *inputPointer, size_t inputLength, const uint8_t *outputPointer);
-void SHA512(const uint8_t *inputPointer, size_t inputLength, const uint8_t *outputPointer);
+void MD5(const uint8_t *inputPointer, size_t inputLength,
+         const uint8_t *outputPointer);
+void SHA1(const uint8_t *inputPointer, size_t inputLength,
+          const uint8_t *outputPointer);
+void SHA256(const uint8_t *inputPointer, size_t inputLength,
+            const uint8_t *outputPointer);
+void SHA384(const uint8_t *inputPointer, size_t inputLength,
+            const uint8_t *outputPointer);
+void SHA512(const uint8_t *inputPointer, size_t inputLength,
+            const uint8_t *outputPointer);
 
 void *hashNew(int32_t hashAlgorithm);
-void hashWrite(int32_t hashAlgorithm, void *ptr, const uint8_t *data, int length);
+void hashWrite(int32_t hashAlgorithm, void *ptr, const uint8_t *data,
+               int length);
 void hashSum(int32_t hashAlgorithm, void *ptr, uint8_t *outputPointer);
 void hashReset(int32_t hashAlgorithm, void *ptr);
 int hashSize(int32_t hashAlgorithm);

--- a/internal/cryptokit/hash.go
+++ b/internal/cryptokit/hash.go
@@ -60,16 +60,6 @@ var (
 	SHA512Size      = int(C.hashSize(sha512))
 )
 
-// cloneHash is an interface that defines a Clone method.
-//
-// hash.CloneHash will probably be added in Go 1.25, see https://golang.org/issue/69521,
-// but we need it now.
-type HashCloner interface {
-	hash.Hash
-	// Clone returns a separate Hash instance with the same state as h.
-	Clone() (HashCloner, error)
-}
-
 var _ hash.Hash = (*evpHash)(nil)
 var _ HashCloner = (*evpHash)(nil)
 

--- a/internal/cryptokit/hash.go
+++ b/internal/cryptokit/hash.go
@@ -64,14 +64,14 @@ var (
 //
 // hash.CloneHash will probably be added in Go 1.25, see https://golang.org/issue/69521,
 // but we need it now.
-type cloneHash interface {
+type HashCloner interface {
 	hash.Hash
 	// Clone returns a separate Hash instance with the same state as h.
-	Clone() (hash.Hash, error)
+	Clone() (HashCloner, error)
 }
 
 var _ hash.Hash = (*evpHash)(nil)
-var _ cloneHash = (*evpHash)(nil)
+var _ HashCloner = (*evpHash)(nil)
 
 type evpHash struct {
 	ptr           unsafe.Pointer
@@ -100,7 +100,7 @@ func (h *evpHash) finalize() {
 	}
 }
 
-func (h *evpHash) Clone() (hash.Hash, error) {
+func (h *evpHash) Clone() (HashCloner, error) {
 	if h.ptr == nil {
 		panic("cryptokit: hash already finalized")
 	}

--- a/internal/cryptokit/hash.go
+++ b/internal/cryptokit/hash.go
@@ -67,7 +67,7 @@ var (
 type cloneHash interface {
 	hash.Hash
 	// Clone returns a separate Hash instance with the same state as h.
-	Clone() hash.Hash
+	Clone() (hash.Hash, error)
 }
 
 var _ hash.Hash = (*evpHash)(nil)
@@ -100,16 +100,16 @@ func (h *evpHash) finalize() {
 	}
 }
 
-func (h *evpHash) Clone() hash.Hash {
+func (h *evpHash) Clone() (hash.Hash, error) {
 	if h.ptr == nil {
-		return nil
+		panic("cryptokit: hash already finalized")
 	}
 
 	newHash := newEVPHash(C.hashCopy(h.hashAlgorithm, h.ptr), h.hashAlgorithm, h.blockSize, h.size)
 
 	runtime.KeepAlive(h)
 
-	return newHash
+	return newHash, nil
 }
 
 func (h *evpHash) Write(p []byte) (int, error) {

--- a/internal/cryptokit/hashclone.go
+++ b/internal/cryptokit/hashclone.go
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//go:build darwin
+
+package cryptokit
+
+import (
+	"hash"
+)
+
+// HashCloner is an interface that defines a Clone method.
+type HashCloner interface {
+	hash.Hash
+	// Clone returns a separate Hash instance with the same state as h.
+	Clone() (HashCloner, error)
+}

--- a/internal/cryptokit/hashclone_go125.go
+++ b/internal/cryptokit/hashclone_go125.go
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//go:build go1.25 && darwin
+
+package cryptokit
+
+import (
+	"hash"
+)
+
+type HashCloner = hash.Cloner

--- a/internal/cryptokit/hmac.go
+++ b/internal/cryptokit/hmac.go
@@ -16,7 +16,7 @@ import (
 )
 
 var _ hash.Hash = (*cryptoKitHMAC)(nil)
-var _ cloneHash = (*cryptoKitHMAC)(nil)
+var _ HashCloner = (*cryptoKitHMAC)(nil)
 
 type cryptoKitHMAC struct {
 	ptr unsafe.Pointer
@@ -100,7 +100,7 @@ func (h *cryptoKitHMAC) UnmarshalBinary(data []byte) error {
 	return errors.New("cryptokit: hash state is not marshallable")
 }
 
-func (h *cryptoKitHMAC) Clone() (hash.Hash, error) {
+func (h *cryptoKitHMAC) Clone() (HashCloner, error) {
 	if h.ptr == nil {
 		panic("cryptokit: hash already finalized")
 	}

--- a/internal/cryptokit/hmac.go
+++ b/internal/cryptokit/hmac.go
@@ -44,7 +44,7 @@ func NewHMAC(fh func() hash.Hash, key []byte) hash.Hash {
 	}
 
 	hmac := &cryptoKitHMAC{
-		ptr: C.initMAC(
+		ptr: C.initHMAC(
 			C.int(kind),
 			base(key), C.int(len(key)),
 		),
@@ -125,7 +125,7 @@ func (h *cryptoKitHMAC) Reset() {
 		h.ptr,
 	)
 
-	h.ptr = C.initMAC(
+	h.ptr = C.initHMAC(
 		C.int(h.kind),
 		(*C.uint8_t)(&*addrNeverEmpty(h.key)), C.int(len(h.key)),
 	)

--- a/internal/cryptokit/hmac.go
+++ b/internal/cryptokit/hmac.go
@@ -100,7 +100,7 @@ func (h *cryptoKitHMAC) UnmarshalBinary(data []byte) error {
 	return errors.New("cryptokit: hash state is not marshallable")
 }
 
-func (h *cryptoKitHMAC) Clone() hash.Hash {
+func (h *cryptoKitHMAC) Clone() (hash.Hash, error) {
 	panic("cryptokit: hash state is not cloneable")
 }
 

--- a/xcrypto/hash_test.go
+++ b/xcrypto/hash_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/microsoft/go-crypto-darwin/internal/cryptokit"
 	"github.com/microsoft/go-crypto-darwin/xcrypto"
 )
 
@@ -205,17 +206,9 @@ func TestHash_Clone(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			// Here we redefine an interface to ensure that the HashCloner interface
-			// is fully compatible with the hash.Clone interface in Go 1.25+.
-			type hashCloner interface {
-				hash.Hash
-				// Clone returns a separate Hash instance with the same state as h.
-				Clone() (hashCloner, error)
-			}
-
 			// We don't define an interface for the Clone method to avoid other
 			// packages from depending on it. Use type assertion to call it.
-			h2, _ := h.(hashCloner).Clone()
+			h2, _ := h.(cryptokit.HashCloner).Clone()
 			h.Write(msg)
 			h2.Write(msg)
 			if actual, actual2 := h.Sum(nil), h2.Sum(nil); !bytes.Equal(actual, actual2) {

--- a/xcrypto/hash_test.go
+++ b/xcrypto/hash_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/microsoft/go-crypto-darwin/internal/cryptokit"
 	"github.com/microsoft/go-crypto-darwin/xcrypto"
 )
 
@@ -206,7 +207,7 @@ func TestHash_Clone(t *testing.T) {
 			}
 			// We don't define an interface for the Clone method to avoid other
 			// packages from depending on it. Use type assertion to call it.
-			h2, _ := h.(interface{ Clone() (hash.Hash, error) }).Clone()
+			h2, _ := h.(cryptokit.HashCloner).Clone()
 			h.Write(msg)
 			h2.Write(msg)
 			if actual, actual2 := h.Sum(nil), h2.Sum(nil); !bytes.Equal(actual, actual2) {

--- a/xcrypto/hash_test.go
+++ b/xcrypto/hash_test.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/microsoft/go-crypto-darwin/internal/cryptokit"
 	"github.com/microsoft/go-crypto-darwin/xcrypto"
 )
 
@@ -205,9 +204,18 @@ func TestHash_Clone(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+
+			// Here we redefine an interface to ensure that the HashCloner interface
+			// is fully compatible with the hash.Clone interface in Go 1.25+.
+			type hashCloner interface {
+				hash.Hash
+				// Clone returns a separate Hash instance with the same state as h.
+				Clone() (hashCloner, error)
+			}
+
 			// We don't define an interface for the Clone method to avoid other
 			// packages from depending on it. Use type assertion to call it.
-			h2, _ := h.(cryptokit.HashCloner).Clone()
+			h2, _ := h.(hashCloner).Clone()
 			h.Write(msg)
 			h2.Write(msg)
 			if actual, actual2 := h.Sum(nil), h2.Sum(nil); !bytes.Equal(actual, actual2) {

--- a/xcrypto/hash_test.go
+++ b/xcrypto/hash_test.go
@@ -206,7 +206,7 @@ func TestHash_Clone(t *testing.T) {
 			}
 			// We don't define an interface for the Clone method to avoid other
 			// packages from depending on it. Use type assertion to call it.
-			h2 := h.(interface{ Clone() hash.Hash }).Clone()
+			h2, _ := h.(interface{ Clone() (hash.Hash, error) }).Clone()
 			h.Write(msg)
 			h2.Write(msg)
 			if actual, actual2 := h.Sum(nil), h2.Sum(nil); !bytes.Equal(actual, actual2) {

--- a/xcrypto/hash_test.go
+++ b/xcrypto/hash_test.go
@@ -200,19 +200,42 @@ func TestHash_Clone(t *testing.T) {
 			if !xcrypto.SupportsHash(ch) {
 				t.Skip("not supported")
 			}
-			h := cryptoToHash(ch)()
+			h := cryptoToHash(ch)().(cryptokit.HashCloner)
 			_, err := h.Write(msg)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			// We don't define an interface for the Clone method to avoid other
-			// packages from depending on it. Use type assertion to call it.
-			h2, _ := h.(cryptokit.HashCloner).Clone()
-			h.Write(msg)
-			h2.Write(msg)
-			if actual, actual2 := h.Sum(nil), h2.Sum(nil); !bytes.Equal(actual, actual2) {
-				t.Errorf("%s(%q) = 0x%x != cloned 0x%x", ch.String(), msg, actual, actual2)
+			h3, err := h.Clone()
+			if err != nil {
+				t.Fatalf("Clone failed: %v", err)
+			}
+			prefix := []byte("tmp")
+			writeToHash(t, h, prefix)
+			h2, err := h.Clone()
+			if err != nil {
+				t.Fatalf("Clone failed: %v", err)
+			}
+			prefixSum := h.Sum(nil)
+			if !bytes.Equal(prefixSum, h2.Sum(nil)) {
+				t.Fatalf("%T Clone results are inconsistent", h)
+			}
+			suffix := []byte("tmp2")
+			writeToHash(t, h, suffix)
+			writeToHash(t, h3, append(prefix, suffix...))
+			compositeSum := h3.Sum(nil)
+			if !bytes.Equal(h.Sum(nil), compositeSum) {
+				t.Fatalf("%T Clone results are inconsistent", h)
+			}
+			if !bytes.Equal(h2.Sum(nil), prefixSum) {
+				t.Fatalf("%T Clone results are inconsistent", h)
+			}
+			writeToHash(t, h2, suffix)
+			if !bytes.Equal(h.Sum(nil), compositeSum) {
+				t.Fatalf("%T Clone results are inconsistent", h)
+			}
+			if !bytes.Equal(h2.Sum(nil), compositeSum) {
+				t.Fatalf("%T Clone results are inconsistent", h)
 			}
 		})
 	}
@@ -569,3 +592,20 @@ func (h *stubHash) Sum(in []byte) []byte        { return in }
 func (h *stubHash) Reset()                      {}
 func (h *stubHash) Size() int                   { return 0 }
 func (h *stubHash) BlockSize() int              { return 0 }
+
+// Helper function for writing. Verifies that Write does not error.
+func writeToHash(t *testing.T, h hash.Hash, p []byte) {
+	t.Helper()
+
+	before := make([]byte, len(p))
+	copy(before, p)
+
+	n, err := h.Write(p)
+	if err != nil || n != len(p) {
+		t.Errorf("Write returned error; got (%v, %v), want (nil, %v)", err, n, len(p))
+	}
+
+	if !bytes.Equal(p, before) {
+		t.Errorf("Write modified input slice; got %x, want %x", p, before)
+	}
+}


### PR DESCRIPTION
This PR implements upcoming hash.Clone interface on HMAC and hashes for keeping hash.Hash returns compatible with Go 1.25. 