### PR TITLE
ci: update workflow to create pull request instead of pushing directly

### DIFF
--- a/.github/workflows/build-swift.yml
+++ b/.github/workflows/build-swift.yml
@@ -2,31 +2,40 @@
 # Licensed under the MIT License.
 
 on:
-    workflow_dispatch:
-    push:
-        branches:
-            - main
-        paths:
-            - '**/*.swift'
-            - '.github/workflows/build-swift.yml'
-            - 'gen-swift-bindings.sh'
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "**/*.swift"
+      - ".github/workflows/build-swift.yml"
+      - "gen-swift-bindings.sh"
 
 name: Build Swift
 jobs:
-    build:
-        permissions:
-            contents: write
-        runs-on: macos-13
-        steps:
-        - uses: actions/checkout@v4
-        - name: Setup Xcode
-          run: sudo xcode-select --switch /Applications/Xcode_14.1.app
-        - name: Build Swift
-          run: bash gen-swift-bindings.sh
-        - name: Commit changes
-          run: |
-            git config --local user.email "action@github.com"
-            git config --global user.name "GitHub Actions"
-            git add internal/cryptokit/CryptoKit.o
-            git commit -m "Update CryptoKit Object file"
-            git push
+  build:
+    permissions:
+      contents: write
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Xcode
+        run: sudo xcode-select --switch /Applications/Xcode_14.1.app
+      - name: Build Swift
+        run: bash gen-swift-bindings.sh
+      - name: Commit changes and create PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --local user.email "action@github.com"
+          git config --global user.name "GitHub Actions"
+          git add internal/cryptokit/CryptoKit.o
+          if git diff --cached --quiet; then
+            echo "No changes to commit."
+            exit 0
+          fi
+          git commit -m "Update CryptoKit Object file"
+          BRANCH=autogen/update-cryptokit-obj-$(date +%s)
+          git checkout -b $BRANCH
+          git push origin $BRANCH
+          gh pr create --fill --base main --head $BRANCH


### PR DESCRIPTION
We have to enable branch protection on this repo which will break the current swift object file updater workflow