### PR TITLE
codeql: flag cryptotest and gentestvectors as test data

### DIFF
--- a/CodeQL.yml
+++ b/CodeQL.yml
@@ -1,0 +1,4 @@
+path_classifiers:
+  tests:
+    - "internal/cryptotest/*.go"
+    - "cmd/gentestvectors/main.go"


### PR DESCRIPTION
Resolving CodeQL errors in the GH UI is not enough to remove them from the s360 dashboard. We need to actually classify non-prod data