### PR TITLE
Add exclamation mark for versions less than Go 1.25 

### DIFF
--- a/internal/cryptokit/hashclone.go
+++ b/internal/cryptokit/hashclone.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//go:build darwin
+//go:build !go1.25 && darwin
 
 package cryptokit
 


### PR DESCRIPTION
This pull request updates the build constraint in the hashclone.go file to ensure compatibility with Go versions earlier than 1.25.