### PR TITLE
Remove extra methods from HMAC

### DIFF
--- a/internal/cryptokit/hmac.go
+++ b/internal/cryptokit/hmac.go
@@ -8,7 +8,6 @@ package cryptokit
 // #include "cryptokit.h"
 import "C"
 import (
-	"errors"
 	"hash"
 	"runtime"
 	"slices"
@@ -86,18 +85,6 @@ func (h *cryptoKitHMAC) Sum(b []byte) []byte {
 	b = append(b, hashSlice...)
 
 	return b
-}
-
-func (h *cryptoKitHMAC) MarshalBinary() ([]byte, error) {
-	return nil, errors.New("cryptokit: hash state is not marshallable")
-}
-
-func (h *cryptoKitHMAC) AppendBinary(b []byte) ([]byte, error) {
-	return nil, errors.New("cryptokit: hash state is not marshallable")
-}
-
-func (h *cryptoKitHMAC) UnmarshalBinary(data []byte) error {
-	return errors.New("cryptokit: hash state is not marshallable")
 }
 
 func (h *cryptoKitHMAC) Clone() (HashCloner, error) {


### PR DESCRIPTION
Current 1.25 upstream is not supporting HMAC to have binary encoding-decoding and appending functions and fails `NoExtraMethodsAllowed` tests. This PR fixes that.