### PR TITLE
Wrap hash state not marshallable errors with ErrUnsupported

### DIFF
--- a/internal/cryptokit/hash.go
+++ b/internal/cryptokit/hash.go
@@ -9,6 +9,7 @@ package cryptokit
 import "C"
 import (
 	"errors"
+	"fmt"
 	"hash"
 	"runtime"
 	"unsafe"
@@ -149,15 +150,15 @@ func (h *evpHash) Sum(b []byte) []byte {
 }
 
 func (h *evpHash) MarshalBinary() ([]byte, error) {
-	return nil, errors.New("cryptokit: hash state is not marshallable")
+	return nil, fmt.Errorf("cryptokit: hash state is not marshallable: %w", errors.ErrUnsupported)
 }
 
 func (h *evpHash) AppendBinary(b []byte) ([]byte, error) {
-	return nil, errors.New("cryptokit: hash state is not marshallable")
+	return nil, fmt.Errorf("cryptokit: hash state is not marshallable: %w", errors.ErrUnsupported)
 }
 
 func (h *evpHash) UnmarshalBinary(data []byte) error {
-	return errors.New("cryptokit: hash state is not marshallable")
+	return fmt.Errorf("cryptokit: hash state is not marshallable: %w", errors.ErrUnsupported)
 }
 
 func (h *evpHash) Reset() {

--- a/internal/cryptokit/hash.go
+++ b/internal/cryptokit/hash.go
@@ -9,7 +9,6 @@ package cryptokit
 import "C"
 import (
 	"errors"
-	"fmt"
 	"hash"
 	"runtime"
 	"unsafe"
@@ -149,16 +148,26 @@ func (h *evpHash) Sum(b []byte) []byte {
 	return b
 }
 
+type errMarshallUnsupported struct{}
+
+func (e errMarshallUnsupported) Error() string {
+	return "cryptokit: hash state is not marshallable"
+}
+
+func (e errMarshallUnsupported) Unwrap() error {
+	return errors.ErrUnsupported
+}
+
 func (h *evpHash) MarshalBinary() ([]byte, error) {
-	return nil, fmt.Errorf("cryptokit: hash state is not marshallable: %w", errors.ErrUnsupported)
+	return nil, errMarshallUnsupported{}
 }
 
 func (h *evpHash) AppendBinary(b []byte) ([]byte, error) {
-	return nil, fmt.Errorf("cryptokit: hash state is not marshallable: %w", errors.ErrUnsupported)
+	return nil, errMarshallUnsupported{}
 }
 
 func (h *evpHash) UnmarshalBinary(data []byte) error {
-	return fmt.Errorf("cryptokit: hash state is not marshallable: %w", errors.ErrUnsupported)
+	return errMarshallUnsupported{}
 }
 
 func (h *evpHash) Reset() {

--- a/xcrypto/hash_test.go
+++ b/xcrypto/hash_test.go
@@ -7,11 +7,11 @@ import (
 	"bytes"
 	"crypto"
 	"encoding"
+	"errors"
 	"fmt"
 	"hash"
 	"io"
 	"runtime"
-	"strings"
 	"testing"
 
 	"github.com/microsoft/go-crypto-darwin/internal/cryptokit"
@@ -160,7 +160,7 @@ func TestHash_BinaryAppender(t *testing.T) {
 			// Append binary data to the prebuilt slice
 			state, err := hashWithBinaryAppender.AppendBinary(prebuiltSlice)
 			if err != nil {
-				if strings.Contains(err.Error(), "hash state is not marshallable") {
+				if errors.Is(err, errors.ErrUnsupported) {
 					t.Skip("AppendBinary not supported")
 				}
 				t.Errorf("could not append binary: %v", err)


### PR DESCRIPTION
This pull request refactors error handling in the CNG package to provide easier to assert error messages by wrapping errors with additional context using errors.ErrUnsupported. It also includes minor import adjustments in the affected files.
This PR addresses one of the steps of: https://github.com/microsoft/go/issues/1683