### PR TITLE
Remove error print statements in AES functions

### DIFF
--- a/cryptokit/Sources/CryptoKitSrc/aes.swift
+++ b/cryptokit/Sources/CryptoKitSrc/aes.swift
@@ -38,7 +38,6 @@ public func encryptAESGCM(
         resultTag.copyBytes(to: tagPointer, count: sealedBox.tag.count)
         return 0
     } catch {
-        print("Encryption failed with error: \(error)")
         return 1
     }
 }
@@ -74,7 +73,6 @@ public func decryptAESGCM(
         outLength.pointee = decryptedData.count
         return 0
     } catch {
-        print("Decryption failed with error: \(error)")
         return 1
     }
 }


### PR DESCRIPTION
Removed print statements for encryption and decryption errors. Probably a leftover from when those functions were being implemented.