### PR TITLE
Add MS_GO_NOSYSTEMCRYPTO env variable for go generate

### DIFF
--- a/.github/workflows/build-swift.yml
+++ b/.github/workflows/build-swift.yml
@@ -37,6 +37,8 @@ jobs:
 
       - name: Run go generate
         run: go generate ./...
+        env:
+          MS_GO_NOSYSTEMCRYPTO: "1" # Don't use systemcryypto as it will detect duplicate symbols in the object files
 
       - name: Commit and Push Changes
         env:

--- a/.github/workflows/build-swift.yml
+++ b/.github/workflows/build-swift.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run go generate
         run: go generate ./...
         env:
-          MS_GO_NOSYSTEMCRYPTO: "1" # Don't use systemcrypto as it will detect duplicate symbols in the object files
+          MS_GO_NOSYSTEMCRYPTO: "1" # Disable systemcrypto to avoid duplicate-symbol/object-file linker errors during go generate
 
       - name: Commit and Push Changes
         env:

--- a/.github/workflows/build-swift.yml
+++ b/.github/workflows/build-swift.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run go generate
         run: go generate ./...
         env:
-          MS_GO_NOSYSTEMCRYPTO: "1" # Don't use systemcryypto as it will detect duplicate symbols in the object files
+          MS_GO_NOSYSTEMCRYPTO: "1" # Don't use systemcrypto as it will detect duplicate symbols in the object files
 
       - name: Commit and Push Changes
         env:


### PR DESCRIPTION
Currently the swift build job is failing because it's detecting multiple object files with the same symbols.

Disable systemcrypto to avoid duplicate symbols in object files.