### PR TITLE
Address improper castings

### DIFF
--- a/internal/security/shims.h
+++ b/internal/security/shims.h
@@ -43,7 +43,7 @@ typedef enum {
 } CFStringEncoding;
 
 typedef enum {
-  kCFNumberIntType = 9
+  kCFNumberLongType = 10
 } CFNumberType;
 
 extern const CFAllocatorRef kCFAllocatorDefault __attribute__((framework(CoreFoundation, A)));

--- a/internal/security/shims.h
+++ b/internal/security/shims.h
@@ -28,7 +28,7 @@ typedef void *CFErrorRef;
 typedef void *CFAllocatorRef;
 typedef void *CFDictionaryKeyCallBacks;
 typedef void *CFDictionaryValueCallBacks;
-typedef int32_t CFIndex;
+typedef long CFIndex;
 typedef CFStringRef SecKeyAlgorithm;
 
 typedef enum {

--- a/internal/security/zsecurity.go
+++ b/internal/security/zsecurity.go
@@ -17,5 +17,5 @@ const (
 )
 
 const (
-	KCFNumberIntType CFNumberType = 9
+	KCFNumberLongType CFNumberType = 10
 )

--- a/internal/security/zsecurity.h
+++ b/internal/security/zsecurity.h
@@ -66,7 +66,7 @@ typedef enum {
 } CFStringEncoding;
 
 typedef enum {
-	kCFNumberIntType = 9,
+	kCFNumberLongType = 10,
 } CFNumberType;
 
 uintptr_t mkcgo_err_retrieve();

--- a/internal/security/zsecurity.h
+++ b/internal/security/zsecurity.h
@@ -23,7 +23,7 @@ typedef void* CFErrorRef;
 typedef void* CFAllocatorRef;
 typedef void* CFDictionaryKeyCallBacks;
 typedef void* CFDictionaryValueCallBacks;
-typedef int32_t CFIndex;
+typedef long CFIndex;
 typedef CFStringRef SecKeyAlgorithm;
 
 extern const CFAllocatorRef kCFAllocatorDefault;

--- a/internal/security/zsecurity_nocgo.go
+++ b/internal/security/zsecurity_nocgo.go
@@ -40,7 +40,7 @@ type CFErrorRef unsafe.Pointer
 type CFAllocatorRef unsafe.Pointer
 type CFDictionaryKeyCallBacks unsafe.Pointer
 type CFDictionaryValueCallBacks unsafe.Pointer
-type CFIndex = int32
+type CFIndex = int64
 type SecKeyAlgorithm = CFStringRef
 
 type SecKeyOperationType int32

--- a/xcrypto/evp.go
+++ b/xcrypto/evp.go
@@ -9,6 +9,7 @@ import (
 	"crypto"
 	"errors"
 	"hash"
+	"math"
 	"slices"
 	"strconv"
 	"unsafe"
@@ -308,7 +309,12 @@ func createSecKeyRandom(keyType security.CFStringRef, keySize int) ([]byte, secu
 		unsafe.Pointer(keyType),
 	)
 
-	cfNum := security.CFNumberCreate(security.KCFAllocatorDefault, security.KCFNumberIntType, unsafe.Pointer(&keySize))
+	// kCFNumberIntType reads a C int (4 bytes). Use an int32 to match.
+	if keySize < 0 || keySize > math.MaxInt32 {
+		return nil, nil, errors.New("xcrypto: key size out of int32 range")
+	}
+	keySizeInt32 := int32(keySize)
+	cfNum := security.CFNumberCreate(security.KCFAllocatorDefault, security.KCFNumberIntType, unsafe.Pointer(&keySizeInt32))
 	defer security.CFRelease(security.CFTypeRef(cfNum))
 
 	security.CFDictionarySetValue(

--- a/xcrypto/evp.go
+++ b/xcrypto/evp.go
@@ -9,7 +9,6 @@ import (
 	"crypto"
 	"errors"
 	"hash"
-	"math"
 	"slices"
 	"strconv"
 	"unsafe"
@@ -309,12 +308,7 @@ func createSecKeyRandom(keyType security.CFStringRef, keySize int) ([]byte, secu
 		unsafe.Pointer(keyType),
 	)
 
-	// kCFNumberIntType reads a C int (4 bytes). Use an int32 to match.
-	if keySize < 0 || keySize > math.MaxInt32 {
-		return nil, nil, errors.New("xcrypto: key size out of int32 range")
-	}
-	keySizeInt32 := int32(keySize)
-	cfNum := security.CFNumberCreate(security.KCFAllocatorDefault, security.KCFNumberIntType, unsafe.Pointer(&keySizeInt32))
+	cfNum := security.CFNumberCreate(security.KCFAllocatorDefault, security.KCFNumberLongType, unsafe.Pointer(&keySize))
 	defer security.CFRelease(security.CFTypeRef(cfNum))
 
 	security.CFDictionarySetValue(

--- a/xcrypto/pbkdf2.go
+++ b/xcrypto/pbkdf2.go
@@ -9,6 +9,7 @@ import (
 	"crypto"
 	"errors"
 	"hash"
+	"math"
 
 	"github.com/microsoft/go-crypto-darwin/internal/commoncrypto"
 )
@@ -28,6 +29,10 @@ func PBKDF2(password, salt []byte, iter, keyLen int, fh func() hash.Hash) ([]byt
 
 	// Allocate output buffer for the derived key
 	derivedKey := make([]byte, keyLen)
+
+	if iter <= 0 || iter > math.MaxUint32 {
+		return nil, errors.New("PBKDF2: invalid iteration count")
+	}
 
 	// Call CommonCrypto's PBKDF2 implementation
 	status := commoncrypto.CCKeyDerivationPBKDF(

--- a/xcrypto/pbkdf2.go
+++ b/xcrypto/pbkdf2.go
@@ -15,6 +15,13 @@ import (
 )
 
 func PBKDF2(password, salt []byte, iter, keyLen int, fh func() hash.Hash) ([]byte, error) {
+	// CommonCrypto's CCKeyDerivationPBKDF takes an unsigned 32-bit iteration
+	// count, so reject values that would overflow or wrap. In practice the
+	// recommended iteration count is around 300,000.
+	if iter <= 0 || iter > math.MaxUint32 {
+		return nil, errors.New("PBKDF2: invalid iteration count")
+	}
+
 	// Map Go hash function to CommonCrypto hash constant
 	ccDigest, err := hashToCCDigestPBKDF2(fh())
 	if err != nil {
@@ -29,10 +36,6 @@ func PBKDF2(password, salt []byte, iter, keyLen int, fh func() hash.Hash) ([]byt
 
 	// Allocate output buffer for the derived key
 	derivedKey := make([]byte, keyLen)
-
-	if iter <= 0 || iter > math.MaxUint32 {
-		return nil, errors.New("PBKDF2: invalid iteration count")
-	}
 
 	// Call CommonCrypto's PBKDF2 implementation
 	status := commoncrypto.CCKeyDerivationPBKDF(


### PR DESCRIPTION


**Fix integer overflow issues in darwin backend**

Fixes: https://github.com/microsoft/go-lab/issues/315

Audited the shims and Go wrappers for narrowing integer conversions. Found and fixed three issues:

**`CFIndex` type width in security shims**

`CFIndex` was declared as `int32_t`, but Apple defines it as `signed long` (64-bit on LP64 macOS). This caused the generated bindings to truncate return values from `CFDataGetLength`, `CFErrorGetCode`, and `CFStringGetLength`, and to narrow slice lengths passed to `CFDataCreate`. Changed to `long` and regenerated bindings.

**`uint32(iter)` in PBKDF2**

The PBKDF2 iteration count (`int`, 64-bit) was cast to `uint32` without validation. Out-of-range values would silently wrap, potentially reducing iterations to near-zero. Added a bounds check.

**`CFNumberCreate` type mismatch in evp**

`kCFNumberIntType` tells `CFNumberCreate` to read 4 bytes, but the pointer passed was to a Go `int` (8 bytes). Used an `int32` local to match the declared read width.
