### PR TITLE
Add benchmark workflow using shared go-infra reusable workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -30,7 +30,7 @@ env:
 # microsoft/go-infra. Repin to the merge-commit SHA before merging this PR.
 jobs:
   setup:
-    uses: microsoft/go-infra/.github/workflows/benchmark-setup.yml@afe5d5b790efe90fd4531a895b4d4ba034280318
+    uses: microsoft/go-infra/.github/workflows/benchmark-setup.yml@7ae6224604e62c88b95d8647cb391d8a2d1635a5
     with:
       default-base-ref: main
       dispatch-base-ref: ${{ inputs.base-ref }}
@@ -85,14 +85,14 @@ jobs:
           go test -run='^$' -bench=. -count=10 -benchmem -timeout 60m ./... 2>&1 | tee ../head.txt || true
 
       - name: "Compare and check"
-        uses: microsoft/go-infra/.github/actions/benchcheck-compare@afe5d5b790efe90fd4531a895b4d4ba034280318
+        uses: microsoft/go-infra/.github/actions/benchcheck-compare@7ae6224604e62c88b95d8647cb391d8a2d1635a5
         with:
           artifact-name: benchstat-${{ matrix.macos-version }}-cgo${{ matrix.cgo }}-go${{ matrix.go-version }}
 
   conclusion:
     needs: [setup, bench]
     if: always() && needs.setup.result == 'success'
-    uses: microsoft/go-infra/.github/workflows/benchmark-conclusion.yml@afe5d5b790efe90fd4531a895b4d4ba034280318
+    uses: microsoft/go-infra/.github/workflows/benchmark-conclusion.yml@7ae6224604e62c88b95d8647cb391d8a2d1635a5
     permissions:
       actions: read
       contents: read
@@ -101,4 +101,4 @@ jobs:
       head-ref: ${{ needs.setup.outputs.head-ref }}
       pr-number: ${{ needs.setup.outputs.pr-number }}
       bench-result: ${{ needs.bench.result }}
-      infra-ref: afe5d5b790efe90fd4531a895b4d4ba034280318
+      infra-ref: 7ae6224604e62c88b95d8647cb391d8a2d1635a5

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,14 +23,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-env:
-  MS_GO_NOSYSTEMCRYPTO: "1"
-
 # Pinned to the SHA of the add-benchcheck-and-benchmark-workflows branch in
 # microsoft/go-infra. Repin to the merge-commit SHA before merging this PR.
 jobs:
   setup:
-    uses: microsoft/go-infra/.github/workflows/benchmark-setup.yml@4e55a96cf2ae064aab767674b96bf0512db7a5d8
+    uses: microsoft/go-infra/.github/workflows/benchmark-setup.yml@ac07251bf61c20b3ec1f090f519c546a7f9807ff
     with:
       default-base-ref: main
       dispatch-base-ref: ${{ inputs.base-ref }}
@@ -44,56 +41,21 @@ jobs:
         macos-version: [macos-14, macos-15, macos-15-intel, macos-26]
         cgo: [1]
     name: bench (${{ matrix.macos-version }}, cgo${{ matrix.cgo }}, go${{ matrix.go-version }})
-    runs-on: ${{ matrix.macos-version }}
-    steps:
-      - name: Initialize status
-        run: echo '{"regression":false,"test_failures":false,"benchmark_error":true}' > status.json
-
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version: ${{ matrix.go-version }}
-          go-download-base-url: "https://aka.ms/golang/release/latest"
-
-      - name: Checkout HEAD
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ needs.setup.outputs.head-ref }}
-          path: head
-
-      - name: Checkout BASE
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ needs.setup.outputs.base-ref }}
-          path: base
-
-      - name: Select Xcode 26.4
-        if: matrix.macos-version == 'macos-26'
-        run: sudo xcode-select -s /Applications/Xcode_26.4.app
-
-      - name: Run benchmarks (base)
-        working-directory: base
-        env:
-          CGO_ENABLED: ${{ matrix.cgo }}
-        run: |
-          go test -run='^$' -bench=. -count=10 -benchmem -timeout 60m ./... 2>&1 | tee ../base.txt || true
-
-      - name: Run benchmarks (head)
-        working-directory: head
-        env:
-          CGO_ENABLED: ${{ matrix.cgo }}
-        run: |
-          go test -run='^$' -bench=. -count=10 -benchmem -timeout 60m ./... 2>&1 | tee ../head.txt || true
-
-      - name: "Compare and check"
-        uses: microsoft/go-infra/.github/actions/benchcheck-compare@4e55a96cf2ae064aab767674b96bf0512db7a5d8
-        with:
-          artifact-name: benchstat-${{ matrix.macos-version }}-cgo${{ matrix.cgo }}-go${{ matrix.go-version }}
-          infra-ref: 4e55a96cf2ae064aab767674b96bf0512db7a5d8
+    uses: microsoft/go-infra/.github/workflows/benchmark-run.yml@ac07251bf61c20b3ec1f090f519c546a7f9807ff
+    with:
+      runs-on: ${{ matrix.macos-version }}
+      go-version: ${{ matrix.go-version }}
+      head-ref: ${{ needs.setup.outputs.head-ref }}
+      base-ref: ${{ needs.setup.outputs.base-ref }}
+      artifact-name: benchstat-${{ matrix.macos-version }}-cgo${{ matrix.cgo }}-go${{ matrix.go-version }}
+      infra-ref: ac07251bf61c20b3ec1f090f519c546a7f9807ff
+      cgo-enabled: ${{ matrix.cgo }}
+      xcode-version: ${{ matrix.macos-version == 'macos-26' && '26.4' || '' }}
 
   conclusion:
     needs: [setup, bench]
     if: always() && needs.setup.result == 'success'
-    uses: microsoft/go-infra/.github/workflows/benchmark-conclusion.yml@4e55a96cf2ae064aab767674b96bf0512db7a5d8
+    uses: microsoft/go-infra/.github/workflows/benchmark-conclusion.yml@ac07251bf61c20b3ec1f090f519c546a7f9807ff
     permissions:
       actions: read
       contents: read
@@ -102,4 +64,4 @@ jobs:
       head-ref: ${{ needs.setup.outputs.head-ref }}
       pr-number: ${{ needs.setup.outputs.pr-number }}
       bench-result: ${{ needs.bench.result }}
-      infra-ref: 4e55a96cf2ae064aab767674b96bf0512db7a5d8
+      infra-ref: ac07251bf61c20b3ec1f090f519c546a7f9807ff

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -30,7 +30,7 @@ env:
 # microsoft/go-infra. Repin to the merge-commit SHA before merging this PR.
 jobs:
   setup:
-    uses: microsoft/go-infra/.github/workflows/benchmark-setup.yml@7ae6224604e62c88b95d8647cb391d8a2d1635a5
+    uses: microsoft/go-infra/.github/workflows/benchmark-setup.yml@4f764ef42aa73aaee0f9e0a573edf9ea78dafba0
     with:
       default-base-ref: main
       dispatch-base-ref: ${{ inputs.base-ref }}
@@ -85,14 +85,15 @@ jobs:
           go test -run='^$' -bench=. -count=10 -benchmem -timeout 60m ./... 2>&1 | tee ../head.txt || true
 
       - name: "Compare and check"
-        uses: microsoft/go-infra/.github/actions/benchcheck-compare@7ae6224604e62c88b95d8647cb391d8a2d1635a5
+        uses: microsoft/go-infra/.github/actions/benchcheck-compare@4f764ef42aa73aaee0f9e0a573edf9ea78dafba0
         with:
           artifact-name: benchstat-${{ matrix.macos-version }}-cgo${{ matrix.cgo }}-go${{ matrix.go-version }}
+          infra-ref: 4f764ef42aa73aaee0f9e0a573edf9ea78dafba0
 
   conclusion:
     needs: [setup, bench]
     if: always() && needs.setup.result == 'success'
-    uses: microsoft/go-infra/.github/workflows/benchmark-conclusion.yml@7ae6224604e62c88b95d8647cb391d8a2d1635a5
+    uses: microsoft/go-infra/.github/workflows/benchmark-conclusion.yml@4f764ef42aa73aaee0f9e0a573edf9ea78dafba0
     permissions:
       actions: read
       contents: read
@@ -101,4 +102,4 @@ jobs:
       head-ref: ${{ needs.setup.outputs.head-ref }}
       pr-number: ${{ needs.setup.outputs.pr-number }}
       bench-result: ${{ needs.bench.result }}
-      infra-ref: 7ae6224604e62c88b95d8647cb391d8a2d1635a5
+      infra-ref: 4f764ef42aa73aaee0f9e0a573edf9ea78dafba0

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,13 +27,12 @@ concurrency:
 # microsoft/go-infra. Repin to the merge-commit SHA before merging this PR.
 jobs:
   benchmark:
-    uses: microsoft/go-infra/.github/workflows/benchmark.yml@6159d42301b70b81263c8c1c9f7091b0ddbe3b19
+    uses: microsoft/go-infra/.github/workflows/benchmark.yml@20f44911f27a3ec701312153cfc23cfa10155e50
     permissions:
       actions: read
       contents: read
       pull-requests: write
     with:
-      infra-ref: 6159d42301b70b81263c8c1c9f7091b0ddbe3b19
       default-base-ref: main
       dispatch-base-ref: ${{ inputs.base-ref }}
       # Cross product of runs-on × go-version, all with cgo enabled. macos-26

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,104 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+name: Benchmark
+
+on:
+  pull_request:
+    paths-ignore:
+      - '.github/**'
+  workflow_dispatch:
+    inputs:
+      base-ref:
+        description: 'Base ref to compare against (branch, tag, or SHA)'
+        required: true
+        default: 'main'
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  MS_GO_NOSYSTEMCRYPTO: "1"
+
+# Pinned to the SHA of the add-benchcheck-and-benchmark-workflows branch in
+# microsoft/go-infra. Repin to the merge-commit SHA before merging this PR.
+jobs:
+  setup:
+    uses: microsoft/go-infra/.github/workflows/benchmark-setup.yml@f321d14481eb6b81bf7d36700a34c6cfc2434ae2
+    with:
+      default-base-ref: main
+      dispatch-base-ref: ${{ inputs.base-ref }}
+
+  bench:
+    needs: setup
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: [1.25, 1.26]
+        macos-version: [macos-14, macos-15, macos-15-intel, macos-26]
+        cgo: [1]
+    name: bench (${{ matrix.macos-version }}, cgo${{ matrix.cgo }}, go${{ matrix.go-version }})
+    runs-on: ${{ matrix.macos-version }}
+    steps:
+      - name: Initialize status
+        run: echo '{"regression":false,"test_failures":false,"benchmark_error":true}' > status.json
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: ${{ matrix.go-version }}
+          go-download-base-url: "https://aka.ms/golang/release/latest"
+
+      - name: Checkout HEAD
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.setup.outputs.head-ref }}
+          path: head
+
+      - name: Checkout BASE
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.setup.outputs.base-ref }}
+          path: base
+
+      - name: Select Xcode 26.4
+        if: matrix.macos-version == 'macos-26'
+        run: sudo xcode-select -s /Applications/Xcode_26.4.app
+
+      - name: Run benchmarks (base)
+        working-directory: base
+        env:
+          CGO_ENABLED: ${{ matrix.cgo }}
+        run: |
+          go test -run='^$' -bench=. -count=10 -benchmem -timeout 60m ./... 2>&1 | tee ../base.txt || true
+
+      - name: Run benchmarks (head)
+        working-directory: head
+        env:
+          CGO_ENABLED: ${{ matrix.cgo }}
+        run: |
+          go test -run='^$' -bench=. -count=10 -benchmem -timeout 60m ./... 2>&1 | tee ../head.txt || true
+
+      - name: "Compare and check"
+        uses: microsoft/go-infra/.github/actions/benchcheck-compare@f321d14481eb6b81bf7d36700a34c6cfc2434ae2
+        with:
+          artifact-name: benchstat-${{ matrix.macos-version }}-cgo${{ matrix.cgo }}-go${{ matrix.go-version }}
+
+  conclusion:
+    needs: [setup, bench]
+    if: always() && needs.setup.result == 'success'
+    uses: microsoft/go-infra/.github/workflows/benchmark-conclusion.yml@f321d14481eb6b81bf7d36700a34c6cfc2434ae2
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+    with:
+      head-ref: ${{ needs.setup.outputs.head-ref }}
+      pr-number: ${{ needs.setup.outputs.pr-number }}
+      bench-result: ${{ needs.bench.result }}
+      infra-ref: f321d14481eb6b81bf7d36700a34c6cfc2434ae2

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -30,7 +30,7 @@ env:
 # microsoft/go-infra. Repin to the merge-commit SHA before merging this PR.
 jobs:
   setup:
-    uses: microsoft/go-infra/.github/workflows/benchmark-setup.yml@4f764ef42aa73aaee0f9e0a573edf9ea78dafba0
+    uses: microsoft/go-infra/.github/workflows/benchmark-setup.yml@30c731c9e1ac8b75b71632de29585b90e88d6cc3
     with:
       default-base-ref: main
       dispatch-base-ref: ${{ inputs.base-ref }}
@@ -85,15 +85,15 @@ jobs:
           go test -run='^$' -bench=. -count=10 -benchmem -timeout 60m ./... 2>&1 | tee ../head.txt || true
 
       - name: "Compare and check"
-        uses: microsoft/go-infra/.github/actions/benchcheck-compare@4f764ef42aa73aaee0f9e0a573edf9ea78dafba0
+        uses: microsoft/go-infra/.github/actions/benchcheck-compare@30c731c9e1ac8b75b71632de29585b90e88d6cc3
         with:
           artifact-name: benchstat-${{ matrix.macos-version }}-cgo${{ matrix.cgo }}-go${{ matrix.go-version }}
-          infra-ref: 4f764ef42aa73aaee0f9e0a573edf9ea78dafba0
+          infra-ref: 30c731c9e1ac8b75b71632de29585b90e88d6cc3
 
   conclusion:
     needs: [setup, bench]
     if: always() && needs.setup.result == 'success'
-    uses: microsoft/go-infra/.github/workflows/benchmark-conclusion.yml@4f764ef42aa73aaee0f9e0a573edf9ea78dafba0
+    uses: microsoft/go-infra/.github/workflows/benchmark-conclusion.yml@30c731c9e1ac8b75b71632de29585b90e88d6cc3
     permissions:
       actions: read
       contents: read
@@ -102,4 +102,4 @@ jobs:
       head-ref: ${{ needs.setup.outputs.head-ref }}
       pr-number: ${{ needs.setup.outputs.pr-number }}
       bench-result: ${{ needs.bench.result }}
-      infra-ref: 4f764ef42aa73aaee0f9e0a573edf9ea78dafba0
+      infra-ref: 30c731c9e1ac8b75b71632de29585b90e88d6cc3

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -30,7 +30,7 @@ env:
 # microsoft/go-infra. Repin to the merge-commit SHA before merging this PR.
 jobs:
   setup:
-    uses: microsoft/go-infra/.github/workflows/benchmark-setup.yml@30c731c9e1ac8b75b71632de29585b90e88d6cc3
+    uses: microsoft/go-infra/.github/workflows/benchmark-setup.yml@4e55a96cf2ae064aab767674b96bf0512db7a5d8
     with:
       default-base-ref: main
       dispatch-base-ref: ${{ inputs.base-ref }}
@@ -85,15 +85,15 @@ jobs:
           go test -run='^$' -bench=. -count=10 -benchmem -timeout 60m ./... 2>&1 | tee ../head.txt || true
 
       - name: "Compare and check"
-        uses: microsoft/go-infra/.github/actions/benchcheck-compare@30c731c9e1ac8b75b71632de29585b90e88d6cc3
+        uses: microsoft/go-infra/.github/actions/benchcheck-compare@4e55a96cf2ae064aab767674b96bf0512db7a5d8
         with:
           artifact-name: benchstat-${{ matrix.macos-version }}-cgo${{ matrix.cgo }}-go${{ matrix.go-version }}
-          infra-ref: 30c731c9e1ac8b75b71632de29585b90e88d6cc3
+          infra-ref: 4e55a96cf2ae064aab767674b96bf0512db7a5d8
 
   conclusion:
     needs: [setup, bench]
     if: always() && needs.setup.result == 'success'
-    uses: microsoft/go-infra/.github/workflows/benchmark-conclusion.yml@30c731c9e1ac8b75b71632de29585b90e88d6cc3
+    uses: microsoft/go-infra/.github/workflows/benchmark-conclusion.yml@4e55a96cf2ae064aab767674b96bf0512db7a5d8
     permissions:
       actions: read
       contents: read
@@ -102,4 +102,4 @@ jobs:
       head-ref: ${{ needs.setup.outputs.head-ref }}
       pr-number: ${{ needs.setup.outputs.pr-number }}
       bench-result: ${{ needs.bench.result }}
-      infra-ref: 30c731c9e1ac8b75b71632de29585b90e88d6cc3
+      infra-ref: 4e55a96cf2ae064aab767674b96bf0512db7a5d8

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -30,7 +30,7 @@ env:
 # microsoft/go-infra. Repin to the merge-commit SHA before merging this PR.
 jobs:
   setup:
-    uses: microsoft/go-infra/.github/workflows/benchmark-setup.yml@f321d14481eb6b81bf7d36700a34c6cfc2434ae2
+    uses: microsoft/go-infra/.github/workflows/benchmark-setup.yml@afe5d5b790efe90fd4531a895b4d4ba034280318
     with:
       default-base-ref: main
       dispatch-base-ref: ${{ inputs.base-ref }}
@@ -85,14 +85,14 @@ jobs:
           go test -run='^$' -bench=. -count=10 -benchmem -timeout 60m ./... 2>&1 | tee ../head.txt || true
 
       - name: "Compare and check"
-        uses: microsoft/go-infra/.github/actions/benchcheck-compare@f321d14481eb6b81bf7d36700a34c6cfc2434ae2
+        uses: microsoft/go-infra/.github/actions/benchcheck-compare@afe5d5b790efe90fd4531a895b4d4ba034280318
         with:
           artifact-name: benchstat-${{ matrix.macos-version }}-cgo${{ matrix.cgo }}-go${{ matrix.go-version }}
 
   conclusion:
     needs: [setup, bench]
     if: always() && needs.setup.result == 'success'
-    uses: microsoft/go-infra/.github/workflows/benchmark-conclusion.yml@f321d14481eb6b81bf7d36700a34c6cfc2434ae2
+    uses: microsoft/go-infra/.github/workflows/benchmark-conclusion.yml@afe5d5b790efe90fd4531a895b4d4ba034280318
     permissions:
       actions: read
       contents: read
@@ -101,4 +101,4 @@ jobs:
       head-ref: ${{ needs.setup.outputs.head-ref }}
       pr-number: ${{ needs.setup.outputs.pr-number }}
       bench-result: ${{ needs.bench.result }}
-      infra-ref: f321d14481eb6b81bf7d36700a34c6cfc2434ae2
+      infra-ref: afe5d5b790efe90fd4531a895b4d4ba034280318

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,45 +23,28 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-# Pinned to the SHA of the add-benchcheck-and-benchmark-workflows branch in
+# Pinned to the SHA of the add-benchmark-workflow branch in
 # microsoft/go-infra. Repin to the merge-commit SHA before merging this PR.
 jobs:
-  setup:
-    uses: microsoft/go-infra/.github/workflows/benchmark-setup.yml@ac07251bf61c20b3ec1f090f519c546a7f9807ff
-    with:
-      default-base-ref: main
-      dispatch-base-ref: ${{ inputs.base-ref }}
-
-  bench:
-    needs: setup
-    strategy:
-      fail-fast: false
-      matrix:
-        go-version: [1.25, 1.26]
-        macos-version: [macos-14, macos-15, macos-15-intel, macos-26]
-        cgo: [1]
-    name: bench (${{ matrix.macos-version }}, cgo${{ matrix.cgo }}, go${{ matrix.go-version }})
-    uses: microsoft/go-infra/.github/workflows/benchmark-run.yml@ac07251bf61c20b3ec1f090f519c546a7f9807ff
-    with:
-      runs-on: ${{ matrix.macos-version }}
-      go-version: ${{ matrix.go-version }}
-      head-ref: ${{ needs.setup.outputs.head-ref }}
-      base-ref: ${{ needs.setup.outputs.base-ref }}
-      artifact-name: benchstat-${{ matrix.macos-version }}-cgo${{ matrix.cgo }}-go${{ matrix.go-version }}
-      infra-ref: ac07251bf61c20b3ec1f090f519c546a7f9807ff
-      cgo-enabled: ${{ matrix.cgo }}
-      xcode-version: ${{ matrix.macos-version == 'macos-26' && '26.4' || '' }}
-
-  conclusion:
-    needs: [setup, bench]
-    if: always() && needs.setup.result == 'success'
-    uses: microsoft/go-infra/.github/workflows/benchmark-conclusion.yml@ac07251bf61c20b3ec1f090f519c546a7f9807ff
+  benchmark:
+    uses: microsoft/go-infra/.github/workflows/benchmark.yml@6159d42301b70b81263c8c1c9f7091b0ddbe3b19
     permissions:
       actions: read
       contents: read
       pull-requests: write
     with:
-      head-ref: ${{ needs.setup.outputs.head-ref }}
-      pr-number: ${{ needs.setup.outputs.pr-number }}
-      bench-result: ${{ needs.bench.result }}
-      infra-ref: ac07251bf61c20b3ec1f090f519c546a7f9807ff
+      infra-ref: 6159d42301b70b81263c8c1c9f7091b0ddbe3b19
+      default-base-ref: main
+      dispatch-base-ref: ${{ inputs.base-ref }}
+      # Cross product of runs-on × go-version, all with cgo enabled. macos-26
+      # cells additionally select Xcode 26.4 via the `include`.
+      matrix: |
+        {
+          "runs-on": ["macos-14", "macos-15", "macos-15-intel", "macos-26"],
+          "go-version": ["1.25", "1.26"],
+          "cgo-enabled": ["1"],
+          "include": [
+            { "runs-on": "macos-26", "go-version": "1.25", "cgo-enabled": "1", "xcode-version": "26.4" },
+            { "runs-on": "macos-26", "go-version": "1.26", "cgo-enabled": "1", "xcode-version": "26.4" }
+          ]
+        }

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,11 +23,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-# Pinned to the SHA of the add-benchmark-workflow branch in
-# microsoft/go-infra. Repin to the merge-commit SHA before merging this PR.
 jobs:
   benchmark:
-    uses: microsoft/go-infra/.github/workflows/benchmark.yml@20f44911f27a3ec701312153cfc23cfa10155e50
+    uses: microsoft/go-infra/.github/workflows/benchmark.yml@5e6a5b28f97bcd009df177f658149009d29d1b1c
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   benchmark:
-    uses: microsoft/go-infra/.github/workflows/benchmark.yml@5e6a5b28f97bcd009df177f658149009d29d1b1c
+    uses: microsoft/go-infra/.github/workflows/benchmark.yml@5e6a5b28f97bcd009df177f658149009d29d1b1c # v0.0.11
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -34,14 +34,13 @@ jobs:
       default-base-ref: main
       dispatch-base-ref: ${{ inputs.base-ref }}
       # Cross product of runs-on × go-version, all with cgo enabled. macos-26
-      # cells additionally select Xcode 26.4 via the `include`.
+      # entries additionally select Xcode 26.4 via the `include`.
       matrix: |
         {
           "runs-on": ["macos-14", "macos-15", "macos-15-intel", "macos-26"],
           "go-version": ["1.25", "1.26"],
           "cgo-enabled": ["1"],
           "include": [
-            { "runs-on": "macos-26", "go-version": "1.25", "cgo-enabled": "1", "xcode-version": "26.4" },
-            { "runs-on": "macos-26", "go-version": "1.26", "cgo-enabled": "1", "xcode-version": "26.4" }
+            { "runs-on": "macos-26", "xcode-version": "26.4" }
           ]
         }

--- a/README.md
+++ b/README.md
@@ -33,3 +33,5 @@ trademarks or logos is subject to and must follow
 [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 Any use of third-party trademarks or logos are subject to those third-party's policies.
+
+<!-- trigger: add-benchmark-workflow -->

--- a/README.md
+++ b/README.md
@@ -33,5 +33,3 @@ trademarks or logos is subject to and must follow
 [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 Any use of third-party trademarks or logos are subject to those third-party's policies.
-
-<!-- trigger: add-benchmark-workflow -->


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for running benchmarks on pull requests and manual dispatches. The workflow leverages a reusable workflow from the `microsoft/go-infra` repository and is configured to run benchmarks across multiple macOS environments and Go versions.

**CI/CD and Benchmarking Enhancements:**

* Added a new `.github/workflows/benchmark.yml` workflow file to automate benchmarking on pull requests and manual triggers. The workflow uses the reusable benchmark workflow from `microsoft/go-infra` and is configured to run on various macOS runners with Go versions 1.25 and 1.26, including specific Xcode selection for `macos-26` runners.
* Configured workflow permissions and concurrency to ensure safe and efficient execution, including cancellation of in-progress runs for the same PR or ref.
* Added support for specifying a custom base reference for comparison via workflow dispatch inputs, defaulting to `main`.