### PR TITLE
xcrypto: fix PBKDF2 benchmarks to use xcrypto hash wrappers

### DIFF
--- a/xcrypto/pbkdf2_test.go
+++ b/xcrypto/pbkdf2_test.go
@@ -5,8 +5,6 @@ package xcrypto_test
 
 import (
 	"bytes"
-	"crypto/sha1"
-	"crypto/sha256"
 	"hash"
 	"testing"
 
@@ -193,9 +191,9 @@ func benchmark(b *testing.B, h func() hash.Hash) {
 }
 
 func BenchmarkPBKDF2HMACSHA1(b *testing.B) {
-	benchmark(b, sha1.New)
+	benchmark(b, xcrypto.NewSHA1)
 }
 
 func BenchmarkPBKDF2HMACSHA256(b *testing.B) {
-	benchmark(b, sha256.New)
+	benchmark(b, xcrypto.NewSHA256)
 }


### PR DESCRIPTION
BenchmarkPBKDF2HMACSHA1/SHA256 passed crypto/sha1.New and crypto/sha256.New to xcrypto.PBKDF2, but xcrypto.PBKDF2 only accepts xcrypto.New* wrappers (and otherwise returns "unsupported hash function"). Use the same wrappers the corresponding tests use.