### PR TITLE
CI: add macos26-intel testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,10 +21,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.25, 1.26]
-        macos-version: [macos-14, macos-15, macos-15-intel, macos-26]
-        cgo: [0, 1]
-        linkmode: ["internal", "external"]
+        go-version: [ 1.25, 1.26 ]
+        macos-version: [ macos-14, macos-15, macos-15-intel, macos-26, macos-26-intel ]
+        cgo: [ 0, 1 ]
+        linkmode: [ "internal", "external" ]
         exclude:
           # CGO_ENABLED=0 is not supported prior to Go 1.26
           - go-version: 1.25
@@ -45,14 +45,18 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run Go Tests
-        run: CGO_ENABLED=${{ matrix.cgo }} go test -gcflags=all=-d=checkptr -ldflags=-linkmode=${{ matrix.linkmode }} -count 10 -shuffle on -v ./...
+        run: CGO_ENABLED=${{ matrix.cgo }} go test -gcflags=all=-d=checkptr
+          -ldflags=-linkmode=${{ matrix.linkmode }} -count 10 -shuffle on -v
+          ./...
 
       - name: Select Xcode 26.4
-        if: matrix.macos-version == 'macos-26'
+        if: matrix.macos-version  == 'macos-26' || matrix.macos-version ==
+          'macos-26-intel'
         run: sudo xcode-select -s /Applications/Xcode_26.4.app
 
       - name: Run Swift Tests
-        if: matrix.macos-version == 'macos-26'
+        if: matrix.macos-version == 'macos-26' || matrix.macos-version ==
+          'macos-26-intel'
         working-directory: cryptokit
         run: swift test
 
@@ -94,7 +98,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        macos-version: [macos-14, macos-15, macos-15-intel, macos-26]
+        macos-version: [ macos-14, macos-15, macos-15-intel, macos-26, macos-26-intel ]
     runs-on: ${{ matrix.macos-version }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
now that the macos26-intel runner is GA we should enable CI testing. This also crucially allows us to bring back swift testing on intel 🎉 