### PR TITLE
Track Xcode version and improve reproducible build checks

### DIFF
--- a/.github/workflows/build-swift.yml
+++ b/.github/workflows/build-swift.yml
@@ -4,7 +4,7 @@
 on:
   workflow_dispatch:
   pull_request:
-    types: [labeled]
+    types: [ labeled ]
   push:
     branches:
       - main
@@ -16,7 +16,8 @@ on:
 name: Build Swift
 jobs:
   build:
-    if: github.event_name != 'pull_request' || github.event.label.name == 'generate-bindings'
+    if: github.event_name != 'pull_request' || github.event.label.name ==
+      'generate-bindings'
     permissions:
       contents: write
       pull-requests: write
@@ -25,7 +26,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || '' }}
+          ref: ${{ github.event_name == 'pull_request' &&
+            github.event.pull_request.head.ref || '' }}
 
       - name: Select Xcode 26.4
         run: sudo xcode-select -s /Applications/Xcode_26.4.app
@@ -52,6 +54,7 @@ jobs:
 
           git add internal/cryptokit/CryptoKit*.syso
           git add internal/cryptokit/zcryptokit_swift_*.go
+          git add internal/cryptokit/xcodebuild_version.txt
 
           if [ "${{ github.event_name }}" == "pull_request" ]; then
             git add internal/cryptokit/zcryptokit.h

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,53 @@ jobs:
         working-directory: cryptokit
         run: swift test
 
+  verify-reproducible-build:
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Select Xcode 26.4
+        run: sudo xcode-select -s /Applications/Xcode_26.4.app
+
+      - name: Backup existing object files
+        run: |
+          mkdir -p backup
+          cp -f internal/cryptokit/CryptoKit_*.syso backup/ 2>/dev/null || true
+          cp -f internal/cryptokit/xcodebuild_version.txt backup/ 2>/dev/null || true
+
+      - name: Rebuild object files
+        run: ./gen-swift-bindings.sh
+
+      - name: Verify Xcode version matches
+        run: |
+          if ! diff -q backup/xcodebuild_version.txt internal/cryptokit/xcodebuild_version.txt >/dev/null 2>&1; then
+            echo "⚠️  WARNING: Xcode version has changed since the last build"
+            echo "Checked-in version:"
+            cat backup/xcodebuild_version.txt
+            echo "Current version:"
+            cat internal/cryptokit/xcodebuild_version.txt
+            echo ""
+            echo "Please re-trigger the build-swift workflow to regenerate bindings with the updated Xcode version."
+            exit 1
+          fi
+          echo "✅ Xcode version matches the checked-in version"
+
+      - name: Verify object files are reproducible
+        run: |
+          if ! diff -q backup/CryptoKit_amd64.syso internal/cryptokit/CryptoKit_amd64.syso >/dev/null 2>&1; then
+            echo "ERROR: CryptoKit_amd64.syso is not reproducible - the checked-in version differs from the rebuilt version"
+            echo "This indicates the object file in the repository is out of sync with the source code"
+            echo "Please rebuild using: ./gen-swift-bindings.sh"
+            exit 1
+          fi
+          if ! diff -q backup/CryptoKit_arm64.syso internal/cryptokit/CryptoKit_arm64.syso >/dev/null 2>&1; then
+            echo "ERROR: CryptoKit_arm64.syso is not reproducible - the checked-in version differs from the rebuilt version"
+            echo "This indicates the object file in the repository is out of sync with the source code"
+            echo "Please rebuild using: ./gen-swift-bindings.sh"
+            exit 1
+          fi
+          echo "✅ Object files are reproducible and match the source code"
+
   linux-x64:
     runs-on: ubuntu-latest
     steps:

--- a/gen-swift-bindings.sh
+++ b/gen-swift-bindings.sh
@@ -9,6 +9,9 @@ cd cryptokit
 # remove any existing per-arch syso files
 rm -f ../internal/cryptokit/CryptoKit_*.syso
 
+# Record the Xcode version used for this build.
+xcodebuild -version > ../internal/cryptokit/xcodebuild_version.txt
+
 echo "Building Swift bindings with swiftc..."
 
 for arch in arm64 x86_64; do

--- a/internal/cryptokit/xcodebuild_version.txt
+++ b/internal/cryptokit/xcodebuild_version.txt
@@ -1,0 +1,2 @@
+Xcode 26.4.1
+Build version 17E202


### PR DESCRIPTION
## Summary

We pin to `/Applications/Xcode_26.4.app` to support the latest `swiftc` features. Since this isn't the stable Xcode version installed on the runner image, it can be bumped (e.g. 26.4 → 26.4.1), causing the `.syso` files to differ unexpectedly.

This PR adds better visibility into Xcode version changes and makes the reproducible build check more informative.

## Changes

- **`gen-swift-bindings.sh`**: Record `xcodebuild -version` output to `internal/cryptokit/xcodebuild_version.txt` during the build
- **`build-swift.yml`**: Include `xcodebuild_version.txt` in the commit step so version changes are tracked
- **`test.yml`**: Add an explicit Xcode version comparison step to `verify-reproducible-build` that clearly flags when a rebuild is necessary due to an Xcode version change
- **`xcodebuild_version.txt`**: New checked-in file recording the Xcode version used for the current `.syso` files

## Note

The `verify-reproducible-build` job is intentionally kept out of the `conclusion` step so it does not break branch protection or block merges of unrelated PRs.

In macOS 27 (expected September 2027), the stable Xcode provided with the runner image will include the `swiftc` features we need, so we can revert to using the default Xcode and these version-pinning issues will no longer apply.