### PR TITLE
Replace gh pr create with issue containing PR creation link

### DIFF
--- a/.github/workflows/build-swift.yml
+++ b/.github/workflows/build-swift.yml
@@ -81,7 +81,8 @@ jobs:
             git push origin $BRANCH
 
             REPO_URL="${{ github.server_url }}/${{ github.repository }}"
-            PR_URL="${REPO_URL}/compare/main...${BRANCH}?expand=1&title=Update%20CryptoKit%20Object%20files"
+            ENCODED_BRANCH=$(printf '%s' "$BRANCH" | sed 's/\//%2F/g')
+            PR_URL="${REPO_URL}/compare/main...${ENCODED_BRANCH}?expand=1&title=Update%20CryptoKit%20Object%20files"
 
             ISSUE_BODY=$(cat <<EOF
           CryptoKit object files have been updated and pushed to branch \`${BRANCH}\`.

--- a/.github/workflows/build-swift.yml
+++ b/.github/workflows/build-swift.yml
@@ -21,6 +21,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
       actions: write
     runs-on: macos-26
     steps:
@@ -78,5 +79,26 @@ jobs:
             BRANCH=autogen/update-cryptokit-obj-$(date +%s)
             git checkout -b $BRANCH
             git push origin $BRANCH
-            gh pr create --fill --base main --head $BRANCH
+
+            REPO_URL="${{ github.server_url }}/${{ github.repository }}"
+            PR_URL="${REPO_URL}/compare/main...${BRANCH}?expand=1&title=Update%20CryptoKit%20Object%20files"
+
+            ISSUE_BODY=$(cat <<EOF
+          CryptoKit object files have been updated and pushed to branch \`${BRANCH}\`.
+
+          **[Click here to create the PR](${PR_URL})**
+
+          This issue will be closed automatically when the PR is merged.
+
+          ---
+          _Automated by the Build Swift workflow, run [#${{ github.run_number }}](${REPO_URL}/actions/runs/${{ github.run_id }})._
+          EOF
+            )
+
+            ISSUE_URL=$(gh issue create \
+              --title "Update CryptoKit Object files (${BRANCH})" \
+              --body "$ISSUE_BODY" \
+              --label "automated")
+
+            echo "Created issue: $ISSUE_URL"
           fi

--- a/.github/workflows/close-autogen-issue.yml
+++ b/.github/workflows/close-autogen-issue.yml
@@ -1,0 +1,35 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+on:
+    delete:
+
+name: Close autogen issue on branch deletion
+jobs:
+    close-issue:
+        if: github.event.ref_type == 'branch' && startsWith(github.event.ref,
+            'autogen/')
+        permissions:
+            issues: write
+        runs-on: ubuntu-latest
+        steps:
+            - name: Close matching issue
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  BRANCH: ${{ github.event.ref }}
+              run: |
+                  ISSUE_NUMBER=$(gh issue list \
+                    --repo "${{ github.repository }}" \
+                    --state open \
+                    --label automated \
+                    --search "Update CryptoKit Object files (${BRANCH})" \
+                    --json number --jq '.[0].number')
+
+                  if [ -n "$ISSUE_NUMBER" ]; then
+                    gh issue close "$ISSUE_NUMBER" \
+                      --repo "${{ github.repository }}" \
+                      --comment "Branch \`${BRANCH}\` has been deleted (likely merged). Closing this issue."
+                    echo "Closed issue #${ISSUE_NUMBER}"
+                  else
+                    echo "No matching open issue found for branch ${BRANCH}"
+                  fi


### PR DESCRIPTION
The GitHub token is prevented from creating PRs at the org level.

fixes: https://github.com/microsoft/go-crypto-darwin/issues/71

Instead of using `gh pr create`, the build-swift workflow now:
- Pushes the autogen branch as before
- Creates an issue with a pre-filled **Click here to create PR** link
- Labels the issue as `automated` for tracking

A new `close-autogen-issue.yml` workflow auto-closes the tracking issue when the autogen branch is deleted (e.g. after PR merge).