### PR TITLE
revert pinning xcode version to 26.4.1

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,13 +6,13 @@ name: Benchmark
 on:
   pull_request:
     paths-ignore:
-      - '.github/**'
+      - ".github/**"
   workflow_dispatch:
     inputs:
       base-ref:
-        description: 'Base ref to compare against (branch, tag, or SHA)'
+        description: "Base ref to compare against (branch, tag, or SHA)"
         required: true
-        default: 'main'
+        default: "main"
 
 permissions:
   actions: read
@@ -34,13 +34,12 @@ jobs:
       default-base-ref: main
       dispatch-base-ref: ${{ inputs.base-ref }}
       # Cross product of runs-on × go-version, all with cgo enabled. macos-26
-      # entries additionally select Xcode 26.4 via the `include`.
       matrix: |
         {
           "runs-on": ["macos-14", "macos-15", "macos-15-intel", "macos-26"],
           "go-version": ["1.25", "1.26"],
           "cgo-enabled": ["1"],
           "include": [
-            { "runs-on": "macos-26", "xcode-version": "26.4" }
+            { "runs-on": "macos-26" }
           ]
         }

--- a/.github/workflows/build-swift.yml
+++ b/.github/workflows/build-swift.yml
@@ -4,7 +4,7 @@
 on:
   workflow_dispatch:
   pull_request:
-    types: [ labeled ]
+    types: [labeled]
   push:
     branches:
       - main
@@ -29,9 +29,6 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request' &&
             github.event.pull_request.head.ref || '' }}
-
-      - name: Select Xcode 26.4
-        run: sudo xcode-select -s /Applications/Xcode_26.4.app
 
       - name: Build Swift
         run: bash gen-swift-bindings.sh

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,10 +44,6 @@ jobs:
         with:
           languages: ${{ matrix.language }}
 
-      - name: Select Xcode 26.4
-        if: matrix.language == 'swift'
-        run: sudo xcode-select -s /Applications/Xcode_26.4.app
-
       - name: Autobuild
         if: matrix.language != 'cpp'
         uses: github/codeql-action/autobuild@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,10 +21,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [ 1.25, 1.26 ]
-        macos-version: [ macos-14, macos-15, macos-15-intel, macos-26, macos-26-intel ]
-        cgo: [ 0, 1 ]
-        linkmode: [ "internal", "external" ]
+        go-version: [1.25, 1.26]
+        macos-version:
+          [macos-14, macos-15, macos-15-intel, macos-26, macos-26-intel]
+        cgo: [0, 1]
+        linkmode: ["internal", "external"]
         exclude:
           # CGO_ENABLED=0 is not supported prior to Go 1.26
           - go-version: 1.25
@@ -49,11 +50,6 @@ jobs:
           -ldflags=-linkmode=${{ matrix.linkmode }} -count 10 -shuffle on -v
           ./...
 
-      - name: Select Xcode 26.4
-        if: matrix.macos-version  == 'macos-26' || matrix.macos-version ==
-          'macos-26-intel'
-        run: sudo xcode-select -s /Applications/Xcode_26.4.app
-
       - name: Run Swift Tests
         if: matrix.macos-version == 'macos-26' || matrix.macos-version ==
           'macos-26-intel'
@@ -64,9 +60,6 @@ jobs:
     runs-on: macos-26
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Select Xcode 26.4
-        run: sudo xcode-select -s /Applications/Xcode_26.4.app
 
       - name: Backup existing object files
         run: |
@@ -145,7 +138,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        macos-version: [ macos-14, macos-15, macos-15-intel, macos-26, macos-26-intel ]
+        macos-version:
+          [macos-14, macos-15, macos-15-intel, macos-26, macos-26-intel]
     runs-on: ${{ matrix.macos-version }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Fortunately for us the default Xcode version on the macOS 26 runners is being bumped to `26.4.1` which means we'll no longer need to run the `xcode-select` workaround: https://github.com/actions/runner-images/issues/14001.