### PR TITLE
fakecgo: remove load_g references

### DIFF
--- a/internal/fakecgo/asm_arm64.s
+++ b/internal/fakecgo/asm_arm64.s
@@ -27,7 +27,6 @@ TEXT crosscall2(SB), NOSPLIT|NOFRAME, $0
 	STP (R29, R30), (8*22)(RSP)
 
 	// Initialize Go ABI environment
-	BL runtime·load_g(SB)
 	BL runtime·cgocallback(SB)
 
 	RESTORE_R19_TO_R28(8*4)

--- a/internal/fakecgo/fakecgo.lock
+++ b/internal/fakecgo/fakecgo.lock
@@ -1,3 +1,3 @@
 {
-  "commit_hash": "5110604b3385278be6887d0feead513a1bfe7a82"
+  "commit_hash": "1512f327e9958354283654ee4497800e33a7b838"
 }


### PR DESCRIPTION
Go 1.27 (tip) introduces stricter checklinkname enforcement for assembly symbols via [golang/go@aee6009](https://github.com/golang/go/commit/aee6009ba5e1d71948b03ac0458fbc99e3a14ace). This causes linker errors when building with CGO_ENABLED=0 on all architectures, because the fakecgo assembly files reference runtime.load_g and runtime.cgocallback, which are now //go:linknamestd (std-only).