### PR TITLE
xcrypto: return concrete Hash from hash constructors

### DIFF
--- a/xcrypto/hash.go
+++ b/xcrypto/hash.go
@@ -34,8 +34,6 @@ type hashAlgorithm struct {
 	blockSize int
 }
 
-type HashCloner = hash.Cloner
-
 var cacheHash sync.Map // map[crypto.Hash]*hashAlgorithm
 
 // supportsSHA3 returns true if SHA-3 is available on this macOS version.
@@ -148,7 +146,7 @@ func (h *Hash) finalize() {
 	}
 }
 
-func (h *Hash) Clone() (HashCloner, error) {
+func (h *Hash) Clone() (hash.Cloner, error) {
 	if h.ptr == nil {
 		panic("cryptokit: hash already finalized")
 	}
@@ -253,7 +251,7 @@ func FIPSApprovedHash(h hash.Hash) bool {
 }
 
 var _ hash.Hash = (*Hash)(nil)
-var _ HashCloner = (*Hash)(nil)
+var _ hash.Cloner = (*Hash)(nil)
 
 func MD5(p []byte) (sum [16]byte) {
 	cryptokit.MD5(p, sum[:])
@@ -296,28 +294,28 @@ func SumSHA3_512(p []byte) (sum [64]byte) {
 }
 
 // NewMD5 initializes a new MD5 hasher.
-func NewMD5() hash.Hash {
+func NewMD5() *Hash {
 	return newHash(crypto.MD5)
 
 }
 
 // NewSHA1 initializes a new SHA1 hasher.
-func NewSHA1() hash.Hash {
+func NewSHA1() *Hash {
 	return newHash(crypto.SHA1)
 }
 
 // NewSHA256 initializes a new SHA256 hasher.
-func NewSHA256() hash.Hash {
+func NewSHA256() *Hash {
 	return newHash(crypto.SHA256)
 }
 
 // NewSHA384 initializes a new SHA384 hasher.
-func NewSHA384() hash.Hash {
+func NewSHA384() *Hash {
 	return newHash(crypto.SHA384)
 }
 
 // NewSHA512 initializes a new SHA512 hasher.
-func NewSHA512() hash.Hash {
+func NewSHA512() *Hash {
 	return newHash(crypto.SHA512)
 }
 

--- a/xcrypto/hash_test.go
+++ b/xcrypto/hash_test.go
@@ -6,7 +6,6 @@ package xcrypto_test
 import (
 	"bytes"
 	"crypto"
-	"encoding"
 	"errors"
 	"fmt"
 	"hash"
@@ -17,7 +16,7 @@ import (
 	"github.com/microsoft/go-crypto-darwin/xcrypto"
 )
 
-func cryptoToHash(h crypto.Hash) func() hash.Hash {
+func cryptoToHash(h crypto.Hash) func() *xcrypto.Hash {
 	switch h {
 	case crypto.MD5:
 		return xcrypto.NewMD5
@@ -30,13 +29,13 @@ func cryptoToHash(h crypto.Hash) func() hash.Hash {
 	case crypto.SHA512:
 		return xcrypto.NewSHA512
 	// case crypto.SHA3_224:
-	// 	return func() hash.Hash { return xcrypto.NewSHA3_224() }
+	// 	return xcrypto.NewSHA3_224
 	case crypto.SHA3_256:
-		return func() hash.Hash { return xcrypto.NewSHA3_256() }
+		return xcrypto.NewSHA3_256
 	case crypto.SHA3_384:
-		return func() hash.Hash { return xcrypto.NewSHA3_384() }
+		return xcrypto.NewSHA3_384
 	case crypto.SHA3_512:
-		return func() hash.Hash { return xcrypto.NewSHA3_512() }
+		return xcrypto.NewSHA3_512
 	}
 	return nil
 }
@@ -101,13 +100,7 @@ func TestHash_BinaryMarshaler(t *testing.T) {
 				t.Skip("hash not supported")
 			}
 
-			hashMarshaler, ok := cryptoToHash(ch)().(interface {
-				hash.Hash
-				encoding.BinaryMarshaler
-			})
-			if !ok {
-				t.Skip("BinaryMarshaler not supported")
-			}
+			hashMarshaler := cryptoToHash(ch)()
 
 			if _, err := hashMarshaler.Write(msg); err != nil {
 				t.Fatalf("Write failed: %v", err)
@@ -118,10 +111,7 @@ func TestHash_BinaryMarshaler(t *testing.T) {
 				t.Fatalf("MarshalBinary failed: %v", err)
 			}
 
-			hashUnmarshaler := cryptoToHash(ch)().(interface {
-				hash.Hash
-				encoding.BinaryUnmarshaler
-			})
+			hashUnmarshaler := cryptoToHash(ch)()
 			if err := hashUnmarshaler.UnmarshalBinary(state); err != nil {
 				t.Fatalf("UnmarshalBinary failed: %v", err)
 			}
@@ -141,10 +131,7 @@ func TestHash_BinaryAppender(t *testing.T) {
 				t.Skip("not supported")
 			}
 
-			hashWithBinaryAppender, ok := cryptoToHash(ch)().(interface {
-				hash.Hash
-				AppendBinary(b []byte) ([]byte, error)
-			})
+			hashWithBinaryAppender := cryptoToHash(ch)()
 
 			// Create a slice with 10 elements
 			prebuiltSlice := make([]byte, 10)
@@ -173,13 +160,7 @@ func TestHash_BinaryAppender(t *testing.T) {
 			// Use only the newly appended part of the slice
 			appendedState := state[10:]
 
-			h2, ok := cryptoToHash(ch)().(interface {
-				hash.Hash
-				encoding.BinaryUnmarshaler
-			})
-			if !ok {
-				t.Skip("not supported")
-			}
+			h2 := cryptoToHash(ch)()
 
 			if err := h2.UnmarshalBinary(appendedState); err != nil {
 				t.Errorf("could not unmarshal: %v", err)
@@ -199,7 +180,7 @@ func TestHash_Clone(t *testing.T) {
 			if !xcrypto.SupportsHash(ch) {
 				t.Skip("not supported")
 			}
-			h := cryptoToHash(ch)().(xcrypto.HashCloner)
+			h := cryptoToHash(ch)()
 			_, err := h.Write(msg)
 			if err != nil {
 				t.Fatal(err)
@@ -248,10 +229,7 @@ func TestHash_ByteWriter(t *testing.T) {
 			if !xcrypto.SupportsHash(ch) {
 				t.Skip("not supported")
 			}
-			bwh := cryptoToHash(ch)().(interface {
-				hash.Hash
-				io.ByteWriter
-			})
+			bwh := cryptoToHash(ch)()
 			initSum := bwh.Sum(nil)
 			for i := range len(msg) {
 				bwh.WriteByte(msg[i])
@@ -275,7 +253,7 @@ func TestHash_StringWriter(t *testing.T) {
 			}
 			h := cryptoToHash(ch)()
 			initSum := h.Sum(nil)
-			h.(io.StringWriter).WriteString(string(msg))
+			h.WriteString(string(msg))
 			h.Reset()
 			sum := h.Sum(nil)
 			if !bytes.Equal(sum, initSum) {

--- a/xcrypto/hkdf.go
+++ b/xcrypto/hkdf.go
@@ -14,7 +14,7 @@ import (
 )
 
 // ExtractHKDF performs the extract step of HKDF using the specified hash function.
-func ExtractHKDF(h func() hash.Hash, secret, salt []byte) ([]byte, error) {
+func ExtractHKDF[H hash.Hash](h func() H, secret, salt []byte) ([]byte, error) {
 	// Handle empty secret
 	if len(secret) == 0 {
 		return nil, errors.New("secret cannot be empty")
@@ -47,7 +47,7 @@ func ExtractHKDF(h func() hash.Hash, secret, salt []byte) ([]byte, error) {
 }
 
 // ExpandHKDF performs the expand step of HKDF using the specified hash function.
-func ExpandHKDF(h func() hash.Hash, pseudorandomKey, info []byte, keyLength int) ([]byte, error) {
+func ExpandHKDF[H hash.Hash](h func() H, pseudorandomKey, info []byte, keyLength int) ([]byte, error) {
 	// Handle empty secret
 	if len(pseudorandomKey) == 0 {
 		return nil, errors.New("pseudorandom key cannot be empty")

--- a/xcrypto/hkdf_test.go
+++ b/xcrypto/hkdf_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 type hkdfTest struct {
-	hash   func() hash.Hash
+	hash   func() *xcrypto.Hash
 	master []byte
 	salt   []byte
 	prk    []byte
@@ -291,7 +291,7 @@ var hkdfTests = []hkdfTest{
 	},
 }
 
-func newHKDF(hash func() hash.Hash, secret, salt, info []byte) ([]byte, error) {
+func newHKDF[H hash.Hash](hash func() H, secret, salt, info []byte) ([]byte, error) {
 	prk, err := xcrypto.ExtractHKDF(hash, secret, salt)
 	if err != nil {
 		return nil, err

--- a/xcrypto/hmac.go
+++ b/xcrypto/hmac.go
@@ -32,23 +32,22 @@ type cryptoKitHMAC struct {
 // CommonCrypto (for example, [NewSHA256]).
 // If fh is not recognized, NewHMAC returns nil.
 func NewHMAC[H hash.Hash](fh func() H, key []byte) hash.Hash {
-	h := fh()
+	h, ok := any(fh()).(*Hash)
+	if !ok || h == nil {
+		return nil
+	}
 
 	// copying the key here to ensure that it is not modified
 	// while this algorithm is using it.
 	key = slices.Clone(key)
-	kind := hashToHMACEnum(h)
-	if kind == 0 {
-		// The hash function is not supported by the HMAC implementation.
-		return nil
-	}
+	kind := h.alg.id
 
 	hmac := &cryptoKitHMAC{
 		ptr:       cryptokit.InitHMAC(kind, key),
 		kind:      kind,
 		key:       key,
-		blockSize: h.BlockSize(),
-		size:      h.Size(),
+		blockSize: h.alg.blockSize,
+		size:      h.alg.size,
 	}
 
 	runtime.SetFinalizer(hmac, func(h *cryptoKitHMAC) {
@@ -104,13 +103,4 @@ func (h *cryptoKitHMAC) Size() int {
 
 func (h *cryptoKitHMAC) BlockSize() int {
 	return h.blockSize
-}
-
-func hashToHMACEnum(h hash.Hash) int32 {
-	switch h := h.(type) {
-	case *Hash:
-		return h.alg.id
-	default:
-		return 0
-	}
 }

--- a/xcrypto/hmac.go
+++ b/xcrypto/hmac.go
@@ -15,7 +15,7 @@ import (
 )
 
 var _ hash.Hash = (*cryptoKitHMAC)(nil)
-var _ HashCloner = (*cryptoKitHMAC)(nil)
+var _ hash.Cloner = (*cryptoKitHMAC)(nil)
 
 type cryptoKitHMAC struct {
 	ptr unsafe.Pointer
@@ -28,14 +28,11 @@ type cryptoKitHMAC struct {
 }
 
 // NewHMAC returns a new HMAC using xcrypto.
-// The function h must return a hash implemented by
-// CommonCrypto (for example, h could be xcrypto.NewSHA256).
-// If h is not recognized, NewHMAC returns nil.
-func NewHMAC(fh func() hash.Hash, key []byte) hash.Hash {
+// The function fh must return a hash implemented by
+// CommonCrypto (for example, [NewSHA256]).
+// If fh is not recognized, NewHMAC returns nil.
+func NewHMAC[H hash.Hash](fh func() H, key []byte) hash.Hash {
 	h := fh()
-	if h == nil {
-		return nil
-	}
 
 	// copying the key here to ensure that it is not modified
 	// while this algorithm is using it.
@@ -78,7 +75,7 @@ func (h *cryptoKitHMAC) Sum(b []byte) []byte {
 	return b
 }
 
-func (h *cryptoKitHMAC) Clone() (HashCloner, error) {
+func (h *cryptoKitHMAC) Clone() (hash.Cloner, error) {
 	if h.ptr == nil {
 		panic("cryptokit: hash already finalized")
 	}

--- a/xcrypto/hmac_test.go
+++ b/xcrypto/hmac_test.go
@@ -5,7 +5,6 @@ package xcrypto_test
 
 import (
 	"bytes"
-	"hash"
 	"testing"
 
 	"github.com/microsoft/go-crypto-darwin/xcrypto"
@@ -14,7 +13,7 @@ import (
 func TestHMAC(t *testing.T) {
 	var tests = []struct {
 		name string
-		fn   func() hash.Hash
+		fn   func() *xcrypto.Hash
 	}{
 		{"md5", xcrypto.NewMD5},
 		{"sha1", xcrypto.NewSHA1},

--- a/xcrypto/hmac_test.go
+++ b/xcrypto/hmac_test.go
@@ -80,14 +80,14 @@ func TestHMACUnsupportedHash(t *testing.T) {
 func TestHMACAllocations(t *testing.T) {
 	msg := []byte("hello world")
 	sum := make([]byte, xcrypto.NewSHA256().Size())
+	h := xcrypto.NewHMAC(xcrypto.NewSHA256, nil)
 	n := int(testing.AllocsPerRun(10, func() {
-		h := xcrypto.NewHMAC(xcrypto.NewSHA256, nil)
 		h.Write(msg)
 		h.Sum(sum[:0])
 		h.Reset()
 	}))
 
-	want := 2
+	want := 0
 	if n > want {
 		t.Errorf("allocs = %d, want %d", n, want)
 	}

--- a/xcrypto/hmac_test.go
+++ b/xcrypto/hmac_test.go
@@ -87,7 +87,7 @@ func TestHMACAllocations(t *testing.T) {
 		h.Reset()
 	}))
 
-	want := 2
+	want := 3
 	if n > want {
 		t.Errorf("allocs = %d, want %d", n, want)
 	}

--- a/xcrypto/hmac_test.go
+++ b/xcrypto/hmac_test.go
@@ -87,7 +87,7 @@ func TestHMACAllocations(t *testing.T) {
 		h.Reset()
 	}))
 
-	want := 3
+	want := 2
 	if n > want {
 		t.Errorf("allocs = %d, want %d", n, want)
 	}

--- a/xcrypto/pbkdf2.go
+++ b/xcrypto/pbkdf2.go
@@ -14,7 +14,7 @@ import (
 	"github.com/microsoft/go-crypto-darwin/internal/commoncrypto"
 )
 
-func PBKDF2(password, salt []byte, iter, keyLen int, fh func() hash.Hash) ([]byte, error) {
+func PBKDF2[H hash.Hash](password, salt []byte, iter, keyLen int, fh func() H) ([]byte, error) {
 	// CommonCrypto's CCKeyDerivationPBKDF takes an unsigned 32-bit iteration
 	// count, so reject values that would overflow or wrap. In practice the
 	// recommended iteration count is around 300,000.

--- a/xcrypto/pbkdf2_test.go
+++ b/xcrypto/pbkdf2_test.go
@@ -148,7 +148,7 @@ var sha256TestVectors = []testVector{
 	},
 }
 
-func testHash(t *testing.T, h func() hash.Hash, hashName string, vectors []testVector) {
+func testHash[H hash.Hash](t *testing.T, h func() H, hashName string, vectors []testVector) {
 	for i, v := range vectors {
 		o, err := xcrypto.PBKDF2([]byte(v.password), []byte(v.salt), v.iter, len(v.output), h)
 		if err != nil {
@@ -177,7 +177,7 @@ func TestPBKDF2WithUnsupportedHash(t *testing.T) {
 	}
 }
 
-func benchmark(b *testing.B, h func() hash.Hash) {
+func benchmark[H hash.Hash](b *testing.B, h func() H) {
 	password := make([]byte, h().Size())
 	salt := make([]byte, 8)
 	var err error


### PR DESCRIPTION
## Summary
- Return concrete `*Hash` values from xcrypto MD5/SHA1/SHA2 hash constructors.
- Parameterize HMAC, HKDF, and PBKDF2 hash factory consumers with `H hash.Hash` so concrete constructors can be passed directly.
- Simplify related tests now that callers no longer need adapter wrappers or type assertions.

## Testing
- `GOOS=darwin go test -c ./xcrypto`