### PR TITLE
Return nil from NewHMAC for hashes CryptoKit cannot HMAC

### DIFF
--- a/xcrypto/hmac.go
+++ b/xcrypto/hmac.go
@@ -37,10 +37,22 @@ func NewHMAC[H hash.Hash](fh func() H, key []byte) hash.Hash {
 		return nil
 	}
 
+	kind := h.alg.id
+	switch kind {
+	case md5, sha1, sha256, sha384, sha512:
+		// Supported by CryptoKit's HMAC.
+	default:
+		// CryptoKit's HMAC only supports MD5, SHA-1, SHA-256, SHA-384, and
+		// SHA-512 (see go_initHMAC in cryptokit.swift). In particular it does
+		// not support SHA-3 and aborts the process if asked. Report any other
+		// hash as unsupported so that NewHMAC returns nil and the caller can
+		// fall back to a pure Go HMAC.
+		return nil
+	}
+
 	// copying the key here to ensure that it is not modified
 	// while this algorithm is using it.
 	key = slices.Clone(key)
-	kind := h.alg.id
 
 	hmac := &cryptoKitHMAC{
 		ptr:       cryptokit.InitHMAC(kind, key),

--- a/xcrypto/hmac_test.go
+++ b/xcrypto/hmac_test.go
@@ -5,6 +5,7 @@ package xcrypto_test
 
 import (
 	"bytes"
+	"crypto"
 	"testing"
 
 	"github.com/microsoft/go-crypto-darwin/xcrypto"
@@ -74,6 +75,32 @@ func TestHMACUnsupportedHash(t *testing.T) {
 	h := xcrypto.NewHMAC(newStubHash, nil)
 	if h != nil {
 		t.Errorf("returned non-nil for unsupported hash")
+	}
+}
+
+// TestHMACSHA3Unsupported is a regression test for
+// https://github.com/microsoft/go/issues/2356. SHA-3 is a recognized
+// xcrypto.Hash, but CryptoKit's HMAC cannot compute it and aborts the process
+// if asked (see go_initHMAC in cryptokit.swift). NewHMAC must report it as
+// unsupported by returning nil so the caller can fall back to a Go HMAC.
+func TestHMACSHA3Unsupported(t *testing.T) {
+	if !xcrypto.SupportsHash(crypto.SHA3_256) {
+		t.Skip("SHA-3 not supported on this macOS version")
+	}
+	tests := []struct {
+		name string
+		fn   func() *xcrypto.Hash
+	}{
+		{"sha3-256", xcrypto.NewSHA3_256},
+		{"sha3-384", xcrypto.NewSHA3_384},
+		{"sha3-512", xcrypto.NewSHA3_512},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if h := xcrypto.NewHMAC(tt.fn, nil); h != nil {
+				t.Errorf("NewHMAC = non-nil, want nil (CryptoKit cannot HMAC %s)", tt.name)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
CryptoKit's HMAC only supports MD5, SHA-1, SHA-256, SHA-384, and SHA-512 (see go_initHMAC in cryptokit.swift). Previously NewHMAC passed the hash id straight to CryptoKit, so asking for HMAC with a recognized but HMAC-unsupported hash such as SHA-3 aborted the process with a Swift fatalError.

Reject any hash outside the supported set by returning nil, which lets the standard library fall back to its pure Go HMAC implementation.

- https://github.com/microsoft/go/issues/2356